### PR TITLE
Add bors for mergebot action

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,8 @@ gce_instance:
 
 # Update metadata on VM images referenced by this repository state
 meta_task:
+    # see bors.toml
+    skip: $CIRRUS_BRANCH =~ ".*\.tmp"
 
     container:
         image: "quay.io/libpod/imgts:master"  # maintained in libpod repo
@@ -64,6 +66,10 @@ gating_task:
 
     # Only run this on PRs, never during post-merge testing.  This is also required
     # for proper setting of EPOCH_TEST_COMMIT value, required by validation tools.
+    
+    # see bors.toml
+    skip: $CIRRUS_BRANCH =~ ".*\.tmp"
+
     only_if: $CIRRUS_BRANCH != $DEST_BRANCH
 
     env:
@@ -85,9 +91,12 @@ gating_task:
         - make unittest
 
 success_task:
-
     # This task is a required-pass in github settings,
     # it blocks PRs from merging if a depends_on task fails
+    
+    # see bors.toml
+    skip: $CIRRUS_BRANCH =~ ".*\.tmp"
+
     only_if: $CIRRUS_BRANCH != $DEST_BRANCH
 
     # ignores any dependent task conditions

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,42 @@
+# Bors-ng is a service which provides a merge and review bot for github PRs.
+# When approved for merging (`bors r+`) or test merging (`bors try`), all
+# pending PRs at the time will be merged together in one of two special
+# branches. Either 'staging' or 'trying'.  In the case of `staging` branch,
+# when all status tests pass (see below) the serialized set of merges will become
+# the new destination branch HEAD (i.e. master).  This guarantees there is never
+# any conflicts with PR merge order on the destination branch(es).
+#
+# Note: The branches 'staging.tmp' and 'trying.tmp' must always be ignored
+# by _all_ CI systems.  They are by bors temporarily, and may go away at
+# unpredictable times.
+#
+# Format Ref: https://bors.tech/documentation/#configuration-borstoml
+#
+# status
+# ------------------
+# Selects which tests are required for merging, matching against values
+# from BOTH the older github 'status API' (ref: https://developer.github.com/v3/repos/statuses
+# /#list-statuses-for-a-specific-ref) AND newer 'checks API'. Ref: https://developer.github.com/v3/checks
+# /runs/#list-check-runs-in-a-check-suite both return JSON:
+#
+# Status API:  Matches against '[].context' values
+# Checks API:  Matches against 'check_runs[].name' values
+#
+# Note: The wild-card character '%' is available.
+status = [
+    "success",
+]
+
+# Same as 'status' (above) but statuses that must pass on every PR
+pr_status = [
+    "success",
+]
+
+# Cirrus-CI Max Timeout is 60 * 60 * 2
+timeout_sec = 7200
+
+# List of strings: PR Labels that must NOT be present
+block_labels = ["wip", "hold"]
+
+# The number of required `bors r+` needed for a PR to merge
+required_approvals = 1


### PR DESCRIPTION
See documentation https://bors.tech/documentation/getting-started/ and https://bors.tech/documentation/

Syntax 		Description
bors r+ 	Run the test suite and push to master if it passes. Short for “reviewed: looks good.”
bors merge 	Equivalent to bors r+.
bors r=[list] 	Same as r+, but the “reviewer” in the commit log will be recorded as the user(s) given as the argument.
bors merge=[list] 	Equivalent to bors r=[list]
bors r- 	Cancel an r+, r=, merge, or merge=
bors merge- 	Equivalent to bors r-
bors try 	Run the test suite without pushing to master.
bors try- 	Cancel a try
bors delegate+
bors d+ 	Allow the pull request author to r+ their changes.
bors delegate=[list]
bors d=[list] 	Allow the listed users to r+ this pull request’s changes.
bors ping 	Check if bors is up. If it is, it will comment with pong.
bors retry 	Run the previous command a second time.
bors p=[priority] 	Set the priority of the current pull request. Pull requests with different priority are never batched together. The pull request with the bigger priority number goes first.
bors r+ p=[priority] 	Set the priority, run the test suite, and push to master (shorthand for doing p= and r+ one after the other).
bors merge p=[priority] 	Equivalent to bors r+ p=[priority]

The keyword (bors) may be separated with a space or a colon. That is, bors try and bors: try are the same thing. Also, the command will be recognized if, and only if, the word “bors” is at the beginning of a line.

Signed-off-by: Brent Baude <bbaude@redhat.com>