### PR TITLE
Fix link to contributing doc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ with APIConnection(uri) as api:
 ```
 
 ## Contributing
-See [CONTRIBUTING.md](https://github.com/containers/podman-py/blob/master/README.md)
+See [CONTRIBUTING.md](https://github.com/containers/podman-py/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Fix link to contributing doc from README
Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>