### PR TITLE
Start networks implementation

### DIFF
--- a/podman/errors/__init__.py
+++ b/podman/errors/__init__.py
@@ -16,6 +16,10 @@ class ImageNotFound(NotFoundError):
     """
 
 
+class NetworkNotFound(NotFoundError):
+    """Network request returned a http.HTTPStatus.NOT_FOUND."""
+
+
 class ContainerNotFound(NotFoundError):
     """HTTP request returned a http.HTTPStatus.NOT_FOUND.
        Specialized for Container not found.
@@ -26,6 +30,13 @@ class PodNotFound(NotFoundError):
     """HTTP request returned a http.HTTPStatus.NOT_FOUND.
        Specialized for Pod not found.
     """
+
+
+class RequestError(HTTPException):
+    """Podman service reported issue with the request"""
+    def __init__(self, message, response=None):
+        super().__init__(message)
+        self.response = response
 
 
 class InternalServerError(HTTPException):

--- a/podman/images/__init__.py
+++ b/podman/images/__init__.py
@@ -40,7 +40,7 @@ def remove(api, name, force=None):
         response = api.delete(path, params)
         return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
-        api.raise_image_not_found(e, e.response)
+        api.raise_not_found(e, e.response)
 
 
 __ALL__ = [

--- a/podman/networks/__init__.py
+++ b/podman/networks/__init__.py
@@ -1,0 +1,70 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""network provides the network operations for a Podman service"""
+import json
+
+import podman.errors as errors
+
+
+def create(api, name, network):
+    """create a network"""
+    if not isinstance(network, str):
+        data = json.dumps(network)
+    else:
+        data = network
+    path = '/networks/create?name={}'.format(api.quote(name))
+    response = api.post(path,
+                        params=data,
+                        headers={'content-type': 'application/json'})
+    return json.loads(str(response.read(), 'utf-8'))
+
+
+def inspect(api, name):
+    """inspect a network"""
+    try:
+        response = api.get('/networks/{}/json'.format(api.quote(name)))
+        return json.loads(str(response.read(), 'utf-8'))
+    except errors.NotFoundError as e:
+        api.raise_not_found(e, e.response, errors.NetworkNotFound)
+
+
+def list_networks(api, filters=None):
+    """list network useing filter"""
+    filters_param = {}
+    if filters:
+        filters_param = {'filter': filters}
+    response = api.get('/networks/json', filters_param)
+    return json.loads(str(response.read(), 'utf-8'))
+
+
+def remove(api, name, force=None):
+    """Remove named/identified image from Podman storage."""
+    params = {}
+    path = '/networks/{}'.format(api.quote(name))
+    if force is not None:
+        params = {'force': force}
+    try:
+        response = api.delete(path, params)
+        return json.loads(str(response.read(), 'utf-8'))
+    except errors.NotFoundError as e:
+        api.raise_not_found(e, e.response, errors.NetworkNotFound)
+
+
+__ALL__ = [
+    "create",
+    "inspect",
+    "list_networks",
+    "remove",
+]

--- a/podman/system/__init__.py
+++ b/podman/system/__init__.py
@@ -25,7 +25,7 @@ def get_info(api):
         response = api.get("/info")
         return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
-        api.raise_image_not_found(e, e.response)
+        api.raise_not_found(e, e.response)
 
 
 def show_disk_usage(api):
@@ -34,7 +34,7 @@ def show_disk_usage(api):
         response = api.get("/system/df")
         return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
-        api.raise_image_not_found(e, e.response)
+        api.raise_not_found(e, e.response)
 
 
 def _report_not_found(e, response):

--- a/podman/tests/unit/images/test_images.py
+++ b/podman/tests/unit/images/test_images.py
@@ -95,7 +95,7 @@ class TestImages(unittest.TestCase):
         """test remove call with missing image"""
         mock_raise = mock.MagicMock()
         mock_raise.side_effect = podman.errors.ImageNotFound('yikes')
-        self.api.raise_image_not_found = mock_raise
+        self.api.raise_not_found = mock_raise
         self.request.side_effect = podman.errors.NotFoundError('nope')
         self.assertRaises(podman.errors.ImageNotFound,
                           podman.images.remove,

--- a/podman/tests/unit/networks/test_networks.py
+++ b/podman/tests/unit/networks/test_networks.py
@@ -1,0 +1,153 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""podman.networks unit tests"""
+
+import unittest
+
+from unittest import mock
+import json
+import urllib.parse
+import podman.errors
+import podman.networks
+
+
+class TestNetwork(unittest.TestCase):
+    """Test the network calls."""
+
+    def setUp(self):
+        super().setUp()
+        self.request = mock.MagicMock()
+        self.response = mock.MagicMock()
+        self.request.return_value = self.response
+        self.api = mock.MagicMock()
+        self.api.get = self.request
+        self.api.delete = self.request
+        self.api.post = self.request
+        self.api.quote = urllib.parse.quote
+
+    def test_create(self):
+        """test create call"""
+        network = {
+            'DisableDNS': False,
+        }
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'{"Filename":"string"}'
+        self.response.read = mock_read
+        ret = podman.networks.create(self.api, 'test', network)
+        self.assertEqual(ret, {'Filename': 'string'})
+        self.request.assert_called_once_with(
+            '/networks/create?name=test',
+            headers={'content-type': 'application/json'},
+            params='{"DisableDNS": false}')
+
+    def test_create_with_string(self):
+        """test create call with string"""
+        network = {
+            'DisableDNS': False,
+        }
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'{"Filename":"string"}'
+        self.response.read = mock_read
+        ret = podman.networks.create(self.api, 'test', json.dumps(network))
+        self.assertEqual(ret, {'Filename': 'string'})
+        self.request.assert_called_once_with(
+            '/networks/create?name=test',
+            headers={'content-type': 'application/json'},
+            params='{"DisableDNS": false}')
+
+    def test_create_fail(self):
+        """test create call with an error"""
+        network = {
+            'DisableDNS': False,
+        }
+        self.response.status = 400
+        self.request.side_effect = podman.errors.RequestError('meh',
+                                                              self.response)
+        self.assertRaises(podman.errors.RequestError,
+                          podman.networks.create,
+                          self.api, 'test', json.dumps(network))
+
+    def test_inspect(self):
+        """test inspect call"""
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'[{"Name":"podman"}]'
+        self.response.read = mock_read
+        ret = podman.networks.inspect(self.api, 'podman')
+        self.assertEqual(ret, [{'Name': 'podman'}])
+        self.request.assert_called_once_with('/networks/podman/json')
+
+    def test_inspect_missing(self):
+        """test inspect missing network"""
+        self.request.side_effect = podman.errors.NotFoundError('yikes')
+        mock_raise = mock.MagicMock()
+        mock_raise.side_effect = podman.errors.NetworkNotFound('yikes')
+        self.api.raise_not_found = mock_raise
+        self.assertRaises(podman.errors.NetworkNotFound,
+                          podman.networks.inspect,
+                          self.api,
+                          'podman')
+
+    def test_list_networks(self):
+        """test networks list call"""
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'[{"Name":"podman"}]'
+        self.response.read = mock_read
+        ret = podman.networks.list_networks(self.api)
+        self.assertEqual(ret, [{'Name': 'podman'}])
+        self.request.assert_called_once_with('/networks/json', {})
+
+    def test_list_networks_filter(self):
+        """test networks list call with a filter"""
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'[{"Name":"podman"}]'
+        self.response.read = mock_read
+        ret = podman.networks.list_networks(self.api, 'name=podman')
+        self.assertEqual(ret, [{'Name': 'podman'}])
+        self.request.assert_called_once_with('/networks/json',
+                                             {'filter': 'name=podman'})
+
+    def test_remove(self):
+        """test remove call"""
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'[{"deleted": "str","untagged": ["str"]}]'
+        self.response.status = 200
+        self.response.read = mock_read
+        expected = [{'deleted': 'str', 'untagged': ['str']}]
+        ret = podman.networks.remove(self.api, 'foo')
+        self.assertEqual(ret, expected)
+        self.api.delete.assert_called_once_with('/networks/foo', {})
+
+    def test_remove_force(self):
+        """test remove call with force"""
+        mock_read = mock.MagicMock()
+        mock_read.return_value = b'[{"deleted": "str","untagged": ["str"]}]'
+        self.response.status = 200
+        self.response.read = mock_read
+        expected = [{'deleted': 'str', 'untagged': ['str']}]
+        ret = podman.networks.remove(self.api, 'foo', True)
+        self.assertEqual(ret, expected)
+        self.api.delete.assert_called_once_with('/networks/foo',
+                                                {'force': True})
+
+    def test_remove_missing(self):
+        """test remove call with missing network"""
+        mock_raise = mock.MagicMock()
+        mock_raise.side_effect = podman.errors.NetworkNotFound('yikes')
+        self.api.raise_not_found = mock_raise
+        self.request.side_effect = podman.errors.NotFoundError('nope')
+        self.assertRaises(podman.errors.NetworkNotFound,
+                          podman.networks.remove,
+                          self.api,
+                          'foo')

--- a/podman/tests/unit/system/test_system.py
+++ b/podman/tests/unit/system/test_system.py
@@ -63,7 +63,7 @@ class TestSystem(unittest.TestCase):
         self.request.side_effect = podman.errors.NotFoundError('yikes')
         mock_raise = mock.MagicMock()
         mock_raise.side_effect = podman.errors.ImageNotFound('yikes')
-        self.api.raise_image_not_found = mock_raise
+        self.api.raise_not_found = mock_raise
         self.assertRaises(podman.errors.ImageNotFound,
                           podman.system.get_info,
                           self.api)
@@ -82,7 +82,7 @@ class TestSystem(unittest.TestCase):
         self.request.side_effect = podman.errors.NotFoundError('yikes')
         mock_raise = mock.MagicMock()
         mock_raise.side_effect = podman.errors.ImageNotFound('yikes')
-        self.api.raise_image_not_found = mock_raise
+        self.api.raise_not_found = mock_raise
         self.assertRaises(podman.errors.ImageNotFound,
                           podman.system.show_disk_usage,
                           self.api)

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ commands = pylint podman
 [testenv:coverage]
 commands =
     coverage run -m nose
-    coverage report --fail-under=80 --omit=podman/tests/* --omit=.tox/*
+    coverage report -m --skip-covered --fail-under=80 --omit=podman/tests/* --omit=.tox/*


### PR DESCRIPTION
This change also includes a renaming of the api's static function to
raise a not found error to allow for alternative types of not found
exceptions to be raised (e.g. ImageNotFound, NetworkNotFound,
ContainerNotFound, etc)