### PR TITLE
Start of integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ podman-py: env
 
 .PHONY: env
 env:
-	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock -y
+	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock python3-fixtures -y
 	# -- or --
 	# $(PYTHON) -m pip install tox
 	# -- or --

--- a/podman/tests/errors.py
+++ b/podman/tests/errors.py
@@ -1,0 +1,19 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""test error exceptions"""
+
+
+class PodmanNotInstalled(Exception):
+    """Exception when podman is not available"""

--- a/podman/tests/integration/base.py
+++ b/podman/tests/integration/base.py
@@ -1,0 +1,39 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""Base integration test code"""
+
+
+import unittest
+import shutil
+import uuid
+import os
+import fixtures
+import podman.tests.integration.utils as utils
+
+
+@unittest.skipIf(
+    shutil.which('podman') is None, "podman is not installed, skipping integration tests"
+)
+class BaseIntegrationTest(fixtures.TestWithFixtures):
+    """Base Integration test case"""
+
+    def setUp(self):
+        super().setUp()
+        self.test_dir = self.useFixture(fixtures.TempDir()).path
+        self.socket_file = os.path.join(self.test_dir, uuid.uuid4().hex)
+        self.socket_uri = 'unix://{}'.format(self.socket_file)
+        self.service_launcher = utils.PodmanLauncher(self.socket_uri)
+        self.service_launcher.start()
+        self.addCleanup(self.service_launcher.stop)

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -1,0 +1,35 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""images call integration tests"""
+
+
+from podman import images
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+# @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+class TestImages(base.BaseIntegrationTest):
+    """images call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    def test_list_images(self):
+        """integration: images list call"""
+        output = images.list_images(self.api)
+        self.assertTrue(isinstance(output, list))

--- a/podman/tests/integration/test_networks.py
+++ b/podman/tests/integration/test_networks.py
@@ -1,0 +1,46 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""networks calls integration tests"""
+
+
+import unittest
+import os
+from podman import networks
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+@unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+class TestNetworks(base.BaseIntegrationTest):
+    """networks call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    @unittest.skip('not implemented yet')
+    def test_network_create_remove(self):
+        """integration: networks create and remove calls"""
+
+    def test_inspect(self):
+        """integration: networks inspect call"""
+        output = networks.inspect(self.api, 'podman')
+        self.assertEqual('', output)
+
+    def test_list_networks(self):
+        """integration: networks list_networks call"""
+        output = networks.list_networks(self.api)
+        self.assertTrue(len(output) > 0)

--- a/podman/tests/integration/test_system.py
+++ b/podman/tests/integration/test_system.py
@@ -1,0 +1,47 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""system call integration tests"""
+
+from podman import system
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+class TestSystem(base.BaseIntegrationTest):
+    """system call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    def test_info(self):
+        """integration: system info call"""
+        output = system.info(self.api)
+        self.assertTrue('host' in output)
+
+    def test_version(self):
+        """integration: system version call"""
+        output = system.version(self.api)
+        self.assertTrue('Platform' in output)
+        self.assertTrue('Version' in output)
+        self.assertTrue('ApiVersion' in output)
+
+    def test_show_disk_usage(self):
+        """integration: system disk usage call"""
+        output = system.show_disk_usage(self.api)
+        self.assertTrue('Images' in output)
+        self.assertTrue('Containers' in output)
+        self.assertTrue('Volumes' in output)

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -1,0 +1,69 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""Integration Test Utils"""
+
+import shutil
+import subprocess
+import time
+import os
+import podman.tests.errors as errors
+
+
+class PodmanLauncher:
+    """Podman service launcher"""
+
+    def __init__(self, socket_uri, podman_path=None, timeout=0, privileged=False):
+        """create a launcher and build podman command"""
+        self.podman_exe = podman_path
+        if not self.podman_exe:
+            self.podman_exe = shutil.which('podman')
+        if self.podman_exe is None:
+            raise errors.PodmanNotInstalled()
+        self.socket_file = socket_uri.replace('unix://', '')
+        self.proc = None
+        self.cmd = []
+        if privileged:
+            self.cmd.append('sudo')
+        self.cmd = self.cmd + [
+            self.podman_exe,
+            "system",
+            "service",
+            "--time",
+            str(timeout),
+            socket_uri,
+        ]
+
+    def start(self):
+        """start podman service"""
+        print("Launching {}".format(" ".join(self.cmd)))
+        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # wait for socket to be created
+        while not os.path.exists(self.socket_file):
+            time.sleep(0.2)
+
+    def stop(self):
+        """stop podman service"""
+        if not self.proc:
+            return (None, None)
+        self.proc.terminate()
+        try:
+            out, errs = self.proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            out, errs = self.proc.communicate()
+        self.proc = None
+        if errs:
+            print(errs)
+        return (out, errs)


### PR DESCRIPTION
This change adds a base integration class and a podman launcher that can
be used to test the api calls and their expected results. Currently the
podman calls that will work should be ones that can be performed as
rootless. Eventually calls that require privilege (e.g. network) can be
implemented but skipped if the tests are not invoked as root.  It should
be noted that all integration tests will be skipped if a podman
executable is not in the path.

Signed-off-by: Alex Schultz <aschultz@redhat.com>