### PR TITLE
Add python3-fixtures and bump to fedora 33

### DIFF
--- a/contrib/cirrus/gating/Dockerfile
+++ b/contrib/cirrus/gating/Dockerfile
@@ -1,9 +1,10 @@
-FROM registry.fedoraproject.org/fedora:31
+FROM registry.fedoraproject.org/fedora:33
 
 RUN dnf -y install golang \
 			make \
 			git \
 			golang \
 			python3-coverage \
-			python3-pylint && \
+			python3-pylint \
+			python3-fixtures && \
 			dnf -y clean all


### PR DESCRIPTION
The integration tests being written as part of #48 leverage fixtures so
we need it installed when we run pylint or the job fails.  Additionally
this bumps the base container fedora to 33.