### PR TITLE
api_connection: extract message from server response

### DIFF
--- a/podman/api_connection.py
+++ b/podman/api_connection.py
@@ -123,12 +123,19 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
                 response,
             )
         elif response.status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+            try:
+                error_body = response.read()
+                error_message = json.loads(error_body)["message"]
+            except:
+                error_message = (
+                    HTTPStatus.INTERNAL_SERVER_ERROR.description
+                    or HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+                )
             raise errors.InternalServerError(
                 "Request {}:{} failed: {}".format(
                     method,
                     url,
-                    HTTPStatus.INTERNAL_SERVER_ERROR.description
-                    or HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
+                    error_message
                 ),
                 response,
             )


### PR DESCRIPTION
# Behavior prior to this commit:

In the api.request method, the error message returned by the server (for a request that generated an error 500, Internal Server Error) is not captured.
For example we might get:

    podman.errors.InternalServerError: Request POST:/v2.0.0/libpod/containers/create failed: Server got itself in trouble

Instead of:

    Decode(): json: cannot unmarshal string into Go struct field SpecGenerator.cni_networks of type []string

This makes troubleshooting issues in such requests difficult.

# Behavior after this commit:

If the response body is in JSON and includes a "message" property, it is
extracted and included in the message of the exception raised.

closes issue #47

Signed-off-by: Nicolas Galler <ngl@odoo.com>