### PR TITLE
Flesh out Images integration testing 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,8 +39,7 @@ gating_task:
         - make
         - go get github.com/vbatts/git-validation
         - make validate
-        - make unittest
-
+        - make tests
 
 success_task:
     # This task is a required-pass in github settings,

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-master} HEAD)
 HEAD ?= HEAD
 
-export PODMAN_VERSION ?= '1.80'
+export PODMAN_VERSION ?= '3.0.0'
 
 .PHONY: podman-py
 podman-py: env
@@ -17,22 +17,28 @@ podman-py: env
 
 .PHONY: env
 env:
-	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock python3-fixtures -y
-	# -- or --
-	# $(PYTHON) -m pip install tox
-	# -- or --
+	# see contrib/cirrus/gating/Dockerfile
+	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock python3-fixtures \
+		podman -y
+
 .PHONY: lint
 lint:
 	$(PYTHON) -m pylint podman || exit $$(($$? % 4));
+
+.PHONY: tests
+tests:
+	DEBUG=1 coverage run -m unittest discover -s podman/tests
+	coverage report -m --skip-covered --fail-under=80 --omit=./podman/tests/* --omit=.tox/* --omit=/usr/lib/*
 
 .PHONY: unittest
 unittest:
 	coverage run -m unittest discover -s podman/tests/unit
 	coverage report -m --skip-covered --fail-under=80 --omit=./podman/tests/* --omit=.tox/* --omit=/usr/lib/*
 
-# .PHONY: integration
-# integration:
-# 	test/integration/test_runner.sh -v
+.PHONY: integration
+integration:
+	coverage run -m unittest discover -s podman/tests/integration
+	coverage report -m --skip-covered --fail-under=80 --omit=./podman/tests/* --omit=.tox/* --omit=/usr/lib/*
 
 # .PHONY: install
 HEAD ?= HEAD

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ podman-py: env
 
 .PHONY: env
 env:
-	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock -y
+	dnf install python3-coverage python3-pylint python3-requests python3-requests-mock python3-fixtures -y
 	# -- or --
 	# $(PYTHON) -m pip install tox
 	# -- or --

--- a/contrib/cirrus/gating/Dockerfile
+++ b/contrib/cirrus/gating/Dockerfile
@@ -8,5 +8,7 @@ RUN dnf -y install golang \
 			python3-requests-mock \
 			python3-coverage \
 			python3-pylint \
-			python3-fixtures && \
+			python3-fixtures \
+			podman \
+			&& \
 			dnf -y clean all

--- a/podman/__init__.py
+++ b/podman/__init__.py
@@ -1,6 +1,10 @@
 """Podman client module."""
+import logging
+
 from podman.api_connection import ApiConnection
 from podman.client import PodmanClient, from_env
 
+from podman.api.version import __version__
+
 # isort: unique-list
-__all__ = ['ApiConnection', 'PodmanClient', 'from_env']
+__all__ = ['ApiConnection', 'PodmanClient', '__version__', 'from_env']

--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -1,23 +1,37 @@
 """Tools for connecting to a Podman service."""
-
 from podman.api.client import APIClient
-from podman.api.parse_utils import decode_header, parse_repository, prepare_body, prepare_timestamp
-from podman.api.tar_utils import create_tar, prepare_dockerfile, prepare_dockerignore
+from podman.api.parse_utils import (
+    decode_header,
+    parse_repository,
+    prepare_body,
+    prepare_cidr,
+    prepare_timestamp,
+)
+from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_dockerignore
 from podman.api.url_utils import prepare_filters
 
-DEFAULT_TIMEOUT = APIClient.default_timeout
+from . import version
+
+DEFAULT_TIMEOUT: float = 60.0
 DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024
+
+API_VERSION: str = version.__version__
+COMPATIBLE_VERSION: str = version.__compatible_version__
 
 # isort: unique-list
 __all__ = [
     'APIClient',
+    'API_VERSION',
+    'COMPATIBLE_VERSION',
+    'DEFAULT_CHUNK_SIZE',
     'DEFAULT_TIMEOUT',
     'create_tar',
     'decode_header',
-    'prepare_filters',
     'parse_repository',
     'prepare_body',
-    'prepare_dockerfile',
+    'prepare_cidr',
+    'prepare_containerfile',
     'prepare_dockerignore',
+    'prepare_filters',
     'prepare_timestamp',
 ]

--- a/podman/api/parse_utils.py
+++ b/podman/api/parse_utils.py
@@ -1,5 +1,6 @@
 """Helper functions for parsing strings."""
 import base64
+import ipaddress
 import json
 from datetime import datetime
 from typing import Any, Dict, MutableMapping, Optional, Tuple, Union
@@ -59,3 +60,12 @@ def prepare_timestamp(value: Union[datetime, int, None]) -> Optional[int]:
         return delta.seconds + delta.days * 24 * 3600
 
     raise ValueError(f"Type '{type(value)}' is not supported by prepare_timestamp()")
+
+
+def prepare_cidr(value: Union[ipaddress.IPv4Network, ipaddress.IPv6Network]) -> (str, str):
+    """Returns network address and Base64 encoded netmask from CIDR.
+
+    Notes:
+        The return values are dictated by the Go JSON decoder.
+    """
+    return str(value.network_address), base64.b64encode(value.netmask.packed).decode("utf-8")

--- a/podman/api/url_utils.py
+++ b/podman/api/url_utils.py
@@ -39,6 +39,7 @@ def _format_dict(filters, criteria):
     for key, value in filters.items():
         if value is None:
             continue
+        value = str(value)
 
         if key in criteria:
             criteria[key].append(value)

--- a/podman/api/version.py
+++ b/podman/api/version.py
@@ -1,0 +1,3 @@
+"""Version of PodmanPy."""
+__version__ = "3.0.0"
+__compatible_version__ = "1.40"

--- a/podman/client.py
+++ b/podman/client.py
@@ -1,4 +1,5 @@
 """Client for connecting to Podman service."""
+import logging
 import os
 import ssl
 from typing import Any, Dict, Mapping, Optional, Union
@@ -27,6 +28,7 @@ class PodmanClient:
         credstore_env: Optional[Mapping[str, str]] = None,
         use_ssh_client: bool = False,
         max_pool_size: int = 5,
+        **kwargs,
     ) -> None:
         """Instantiate PodmanClient object
 
@@ -40,8 +42,14 @@ class PodmanClient:
             credstore_env: Dict containing environment for credential store
             use_ssh_client: Use system ssh agent rather than ssh module. Default:False
             max_pool_size: Number of connections to save in pool
+            log_level (int): Threshold for logging events. Valid values: logging.CRITICAL,
+                logging.ERROR,   logging.WARNING, logging.INFO, logging.DEBUG.
+                Default: logging.WARNING
         """
-        # FIXME Should parameters be *args, **kwargs and resolved before calling APIClient()?
+        log_level = kwargs.get("log_level", logging.WARNING)
+        if logging.DEBUG < log_level > logging.CRITICAL:
+            raise ValueError(f"Invalid Logging {logging.getLevelName(log_level)}")
+        logging.basicConfig(level=log_level)
 
         if not base_url:
             uid = os.geteuid()
@@ -135,7 +143,6 @@ class PodmanClient:
             version=version,
             timeout=timeout,
             tls=tls,
-            user_agent="Podman/3.0.0",
             credstore_env=credstore_env,
             use_ssh_client=use_ssh_client,
             max_pool_size=max_pool_size,

--- a/podman/config.py
+++ b/podman/config.py
@@ -1,0 +1,110 @@
+"""Read containers.conf file."""
+import os
+import pathlib
+import urllib.parse
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    import toml
+except ImportError:
+    import pytoml as toml
+
+
+class ServiceConnection:
+    """ServiceConnection defines a connection to the Podman service."""
+
+    def __init__(self, name: str, attrs: Dict[str, str]):
+        """Create a Podman ServiceConnection."""
+        self.name = name
+        self.attrs = attrs
+
+    def __repr__(self) -> str:
+        return f"""<{self.__class__.__name__}: '{self.id}'>"""
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.name))
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, ServiceConnection):
+            return self.id == other.id and self.attrs == other.attrs
+        return False
+
+    @property
+    def id(self) -> str:  # pylint: disable=invalid-name
+        """Returns identifier for service connection."""
+        return self.name
+
+    @property
+    @lru_cache(1)
+    def url(self) -> urllib.parse.ParseResult:
+        """Returns URL for service connection."""
+        return urllib.parse.urlparse(self.attrs.get("uri"))
+
+    @property
+    @lru_cache(1)
+    def identity(self) -> Path:
+        """Returns Path to identity file for service connection."""
+        return pathlib.Path(self.attrs.get("identity"))
+
+
+class PodmanConfig:
+    """PodmanConfig provides a representation of the containers.conf file."""
+
+    def __init__(self, path: str = None):
+        """Read Podman configuration from users XDG_CONFIG_HOME."""
+
+        if path is None:
+            home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home()))
+            self.path = home / ".config" / "containers" / "containers.conf"
+        else:
+            self.path = pathlib.Path(path)
+
+        self.attrs = dict()
+        if self.path.exists():
+            with self.path.open() as file:
+                buffer = file.read()
+            self.attrs = toml.loads(buffer)
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.path.name))
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, PodmanConfig):
+            return self.id == other.id and self.attrs == other.attrs
+        return False
+
+    @property
+    def id(self):  # pylint: disable=invalid-name
+        """Returns Path() of container.conf."""
+        return self.path
+
+    @property
+    @lru_cache(1)
+    def services(self) -> Dict[str, ServiceConnection]:
+        """Returns list of service connections."""
+        services: Dict[str, ServiceConnection] = dict()
+
+        engine = self.attrs.get("engine")
+        if engine:
+            destinations = engine.get("service_destinations")
+            for key in destinations:
+                connection = ServiceConnection(key, attrs=destinations[key])
+                services[key] = connection
+
+        return services
+
+    @property
+    @lru_cache(1)
+    def active_service(self) -> Optional[ServiceConnection]:
+        """Returns active connection."""
+
+        engine = self.attrs.get("engine")
+        if engine:
+            active = engine.get("active_service")
+            destinations = engine.get("service_destinations")
+            for key in destinations:
+                if key == active:
+                    return ServiceConnection(key, attrs=destinations[key])
+        return None

--- a/podman/domain/networks.py
+++ b/podman/domain/networks.py
@@ -9,6 +9,8 @@ import hashlib
 import json
 from typing import List, Optional, Union
 
+import requests
+
 from podman.domain.containers import Container
 from podman.domain.manager import PodmanResource
 from podman.errors import APIError
@@ -156,7 +158,10 @@ class Network(PodmanResource):
             f"/networks/{self.name}", params={"force": force}, compatible=compatible
         )
 
-        if response.status_code == 200:
+        if (
+            response.status_code == requests.codes.no_content
+            or response.status_code == requests.codes.okay
+        ):
             return
 
         body = response.json()

--- a/podman/tests/errors.py
+++ b/podman/tests/errors.py
@@ -1,0 +1,19 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""test error exceptions"""
+
+
+class PodmanNotInstalled(Exception):
+    """Exception when podman is not available"""

--- a/podman/tests/integration/base.py
+++ b/podman/tests/integration/base.py
@@ -1,0 +1,39 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""Base integration test code"""
+
+
+import unittest
+import shutil
+import uuid
+import os
+import fixtures
+import podman.tests.integration.utils as utils
+
+
+@unittest.skipIf(
+    shutil.which('podman') is None, "podman is not installed, skipping integration tests"
+)
+class BaseIntegrationTest(fixtures.TestWithFixtures):
+    """Base Integration test case"""
+
+    def setUp(self):
+        super().setUp()
+        self.test_dir = self.useFixture(fixtures.TempDir()).path
+        self.socket_file = os.path.join(self.test_dir, uuid.uuid4().hex)
+        self.socket_uri = 'unix://{}'.format(self.socket_file)
+        self.service_launcher = utils.PodmanLauncher(self.socket_uri)
+        self.service_launcher.start()
+        self.addCleanup(self.service_launcher.stop)

--- a/podman/tests/integration/base.py
+++ b/podman/tests/integration/base.py
@@ -13,9 +13,7 @@
 #   under the License.
 #
 """Base integration test code"""
-
-
-import unittest
+import logging
 import shutil
 import uuid
 import os
@@ -23,17 +21,30 @@ import fixtures
 import podman.tests.integration.utils as utils
 
 
-@unittest.skipIf(
-    shutil.which('podman') is None, "podman is not installed, skipping integration tests"
-)
-class BaseIntegrationTest(fixtures.TestWithFixtures):
+class IntegrationTest(fixtures.TestWithFixtures):
     """Base Integration test case"""
+
+    podman: str = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        command = os.environ.get("PODMAN_BINARY", "podman")
+        if shutil.which(command) is None:
+            raise AssertionError(f"'{command}' not found.")
+        IntegrationTest.podman = command
 
     def setUp(self):
         super().setUp()
+
+        self.log_level = logging.WARNING
+        if "DEBUG" in os.environ:
+            self.log_level = logging.DEBUG
+
         self.test_dir = self.useFixture(fixtures.TempDir()).path
         self.socket_file = os.path.join(self.test_dir, uuid.uuid4().hex)
-        self.socket_uri = 'unix://{}'.format(self.socket_file)
-        self.service_launcher = utils.PodmanLauncher(self.socket_uri)
+        self.socket_uri = f'unix://{self.socket_file}'
+        self.service_launcher = utils.PodmanLauncher(
+            self.socket_uri, podman_path=IntegrationTest.podman, log_level=self.log_level
+        )
         self.service_launcher.start()
         self.addCleanup(self.service_launcher.stop)

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -1,0 +1,35 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""images call integration tests"""
+
+
+from podman import images
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+# @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+class TestImages(base.BaseIntegrationTest):
+    """images call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    def test_list_images(self):
+        """integration: images list call"""
+        output = images.list_images(self.api)
+        self.assertTrue(isinstance(output, list))

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -13,23 +13,113 @@
 #   under the License.
 #
 """images call integration tests"""
+import io
+import tarfile
+import unittest
 
-
-from podman import images
-from podman.api_connection import ApiConnection
 import podman.tests.integration.base as base
+from podman import PodmanClient
+from podman.domain.images import Image
+from podman.errors.exceptions import ImageNotFound, APIError
 
 
 # @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
-class TestImages(base.BaseIntegrationTest):
+
+
+class TestImages(base.IntegrationTest):
     """images call integration test"""
 
     def setUp(self):
         super().setUp()
-        self.api = ApiConnection(self.socket_uri)
-        self.addCleanup(self.api.close)
 
-    def test_list_images(self):
-        """integration: images list call"""
-        output = images.list_images(self.api)
-        self.assertTrue(isinstance(output, list))
+        self.client = PodmanClient(base_url=self.socket_uri, log_level=self.log_level)
+        self.addCleanup(self.client.close)
+
+    def test_image_crud(self):
+        """Test Image CRUD.
+
+        Notes:
+            Written to maximize re-use of pulled image.
+        """
+
+        with self.subTest("Pull Alpine Image"):
+            image = self.client.images.pull("quay.io/libpod/alpine", tag="latest")
+            self.assertIsInstance(image, Image)
+            self.assertIn("quay.io/libpod/alpine:latest", image.tags)
+
+        with self.subTest("Inspect Alpine Image"):
+            image = self.client.images.get("quay.io/libpod/alpine")
+            self.assertIsInstance(image, Image)
+            self.assertIn("quay.io/libpod/alpine:latest", image.tags)
+
+        with self.subTest("Retrieve Image history"):
+            ids = [i["Id"] for i in image.history()]
+            self.assertIn(image.id, ids)
+
+        with self.subTest("Export Image to tarball (in memory)"):
+            buffer = io.BytesIO()
+            for chunk in image.save():
+                buffer.write(chunk)
+            buffer.seek(0, 0)
+
+            with tarfile.open(fileobj=buffer, mode="r") as tar:
+                items = tar.getnames()
+            self.assertIn("manifest.json", items)
+            self.assertIn("repositories", items)
+
+        with self.subTest("List images"):
+            image_list = self.client.images.list()
+            found = [i for i in image_list if "quay.io/libpod/alpine:latest" in i.tags]
+            self.assertEqual(
+                len(found), 1, "pulled image 'quay.io/libpod/alpine:latest' not listed."
+            )
+
+        with self.subTest("Tag and reload() Image"):
+            self.assertTrue(image.tag("localhost/alpine", "unittest"))
+            image.reload()
+            self.assertIn("localhost/alpine:unittest", image.tags)
+
+        with self.subTest("Delete Image"):
+            actual = self.client.images.remove(image.id, force=True)
+            deleted = [d["Deleted"] for d in actual if "Deleted" in d]
+            self.assertIn(image.id, deleted)
+            untagged = [d["Untagged"] for d in actual if "Untagged" in d]
+            self.assertIn(image.tags[0], untagged)
+            exit_code = [d["ExitCode"] for d in actual if "ExitCode" in d]
+            self.assertIn(0, exit_code)
+
+            with self.assertRaises(ImageNotFound):
+                # verify image deleted before loading below
+                self.client.images.get(image.id)
+
+        with self.subTest("Load Image previously deleted"):
+            buffer.seek(0, 0)
+            new_image = next(iter(self.client.images.load(buffer.getvalue())))
+            self.assertEqual(image.id, new_image.id)
+
+        with self.subTest("Deleted unused Images"):
+            actual = self.client.images.prune()
+            deleted = [d.get("Deleted") for d in actual["ImagesDeleted"]]
+            self.assertIn(image.id, deleted)
+            self.assertGreater(actual["SpaceReclaimed"], 0)
+
+    def test_search(self):
+        actual = self.client.images.search("alpine", filters={"is-official": True})
+        self.assertEqual(len(actual), 1)
+        self.assertEqual(actual[0]["Official"], "[OK]")
+
+    @unittest.skip("Needs Podman 3.1.0")
+    def test_corrupt_load(self):
+        with self.assertRaises(APIError) as e:
+            next(self.client.images.load("This is a corrupt tarball".encode("utf-8")))
+        self.assertIn("payload does not match", e.exception.explanation)
+
+    def test_build(self):
+        buffer = io.StringIO(
+            f"""FROM quay.io/libpod/alpine_labels:latest
+"""
+        )
+
+        image, stream = self.client.images.build(fileobj=buffer)
+        self.assertIsNotNone(image)
+        self.assertIsNotNone(image.id)

--- a/podman/tests/integration/test_networks.py
+++ b/podman/tests/integration/test_networks.py
@@ -1,0 +1,46 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""networks calls integration tests"""
+
+
+import unittest
+import os
+from podman import networks
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+@unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+class TestNetworks(base.BaseIntegrationTest):
+    """networks call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    @unittest.skip('not implemented yet')
+    def test_network_create_remove(self):
+        """integration: networks create and remove calls"""
+
+    def test_inspect(self):
+        """integration: networks inspect call"""
+        output = networks.inspect(self.api, 'podman')
+        self.assertEqual('', output)
+
+    def test_list_networks(self):
+        """integration: networks list_networks call"""
+        output = networks.list_networks(self.api)
+        self.assertTrue(len(output) > 0)

--- a/podman/tests/integration/test_networks.py
+++ b/podman/tests/integration/test_networks.py
@@ -17,30 +17,94 @@
 
 import unittest
 import os
-from podman import networks
+from podman import networks, PodmanClient
 from podman.api_connection import ApiConnection
 import podman.tests.integration.base as base
+from podman.domain.containers import Container
+from podman.domain.ipam import IPAMPool, IPAMConfig
+from podman.errors import NotFound
 
 
-@unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
-class TestNetworks(base.BaseIntegrationTest):
+class TestNetworks(base.IntegrationTest):
     """networks call integration test"""
+
+    pool = IPAMPool(subnet="172.16.0.0/12", iprange="172.16.0.0/16", gateway="172.31.255.254")
+
+    ipam = IPAMConfig(pool_configs=[pool])
 
     def setUp(self):
         super().setUp()
-        self.api = ApiConnection(self.socket_uri)
-        self.addCleanup(self.api.close)
+        self.client = PodmanClient(base_url=self.socket_uri, log_level=self.log_level)
+        self.addCleanup(self.client.close)
 
-    @unittest.skip('not implemented yet')
-    def test_network_create_remove(self):
+    def test_network_crud(self):
         """integration: networks create and remove calls"""
 
-    def test_inspect(self):
-        """integration: networks inspect call"""
-        output = networks.inspect(self.api, 'podman')
-        self.assertEqual('', output)
+        with self.subTest("Create Network"):
+            network = self.client.networks.create(
+                "integration_test",
+                disabled_dns=True,
+                enable_ipv6=False,
+                ipam=TestNetworks.ipam,
+            )
+            self.assertEqual(network.name, "integration_test")
 
-    def test_list_networks(self):
-        """integration: networks list_networks call"""
-        output = networks.list_networks(self.api)
-        self.assertTrue(len(output) > 0)
+        with self.subTest("Inspect Network"):
+            network = self.client.networks.get("integration_test")
+            self.assertEqual(network.name, "integration_test")
+
+        with self.subTest("List Networks"):
+            nets = self.client.networks.list()
+            names = [i.name for i in nets]
+            self.assertIn("integration_test", names)
+
+        with self.subTest("Delete network"):
+            network = self.client.networks.get("integration_test")
+            network.remove(force=True)
+
+            with self.assertRaises(NotFound):
+                self.client.networks.get("integration_test")
+
+    # @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+    @unittest.skip("Additionally network tests need to segregate by network")
+    def test_network_connect(self):
+        alpine_container = Container()
+
+        with self.subTest("Create Network"):
+            network = self.client.networks.create(
+                "integration_test",
+                disabled_dns=True,
+                enable_ipv6=False,
+                ipam=TestNetworks.ipam,
+            )
+            self.assertEqual(network.name, "integration_test")
+
+        # TODO implement network.containers
+        with self.subTest("Connect container to Network"):
+            pre_count = network.containers
+            network.connect(container=alpine_container)
+            network.reload()
+
+            post_count = network.containers
+            self.assertLess(pre_count, post_count)
+
+        with self.subTest("Disconnect container from Network"):
+            pre_count = network.containers
+            network.disconnect(container=alpine_container)
+            network.reload()
+
+            post_count = network.containers
+            self.assertGreater(pre_count, post_count)
+
+    @unittest.skip("Requires Podman 3.1")
+    def test_network_prune(self):
+        network = self.client.networks.create(
+            "integration_test",
+            disabled_dns=True,
+            enable_ipv6=False,
+            ipam=TestNetworks.ipam,
+        )
+        self.assertEqual(network.name, "integration_test")
+
+        report = self.client.networks.prune()
+        self.assertIn(network.name, report["NetworksDeleted"])

--- a/podman/tests/integration/test_system.py
+++ b/podman/tests/integration/test_system.py
@@ -19,7 +19,7 @@ from podman.api_connection import ApiConnection
 import podman.tests.integration.base as base
 
 
-class TestSystem(base.BaseIntegrationTest):
+class TestSystem(base.IntegrationTest):
     """system call integration test"""
 
     def setUp(self):

--- a/podman/tests/integration/test_system.py
+++ b/podman/tests/integration/test_system.py
@@ -1,0 +1,47 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""system call integration tests"""
+
+from podman import system
+from podman.api_connection import ApiConnection
+import podman.tests.integration.base as base
+
+
+class TestSystem(base.BaseIntegrationTest):
+    """system call integration test"""
+
+    def setUp(self):
+        super().setUp()
+        self.api = ApiConnection(self.socket_uri)
+        self.addCleanup(self.api.close)
+
+    def test_info(self):
+        """integration: system info call"""
+        output = system.info(self.api)
+        self.assertTrue('host' in output)
+
+    def test_version(self):
+        """integration: system version call"""
+        output = system.version(self.api)
+        self.assertTrue('Platform' in output)
+        self.assertTrue('Version' in output)
+        self.assertTrue('ApiVersion' in output)
+
+    def test_show_disk_usage(self):
+        """integration: system disk usage call"""
+        output = system.show_disk_usage(self.api)
+        self.assertTrue('Images' in output)
+        self.assertTrue('Containers' in output)
+        self.assertTrue('Volumes' in output)

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -13,57 +13,92 @@
 #   under the License.
 #
 """Integration Test Utils"""
-
+import logging
+import os
+import pathlib
 import shutil
 import subprocess
+import tempfile
 import time
-import os
+from typing import List, Optional
+
 import podman.tests.errors as errors
+
+logger = logging.getLogger("fixture")
 
 
 class PodmanLauncher:
     """Podman service launcher"""
 
-    def __init__(self, socket_uri, podman_path=None, timeout=0, privileged=False):
+    def __init__(
+        self,
+        socket_uri: str,
+        podman_path: Optional[str] = None,
+        timeout: int = 0,
+        privileged: bool = False,
+        log_level: int = logging.WARNING,
+    ) -> None:
         """create a launcher and build podman command"""
-        self.podman_exe = podman_path
-        if not self.podman_exe:
-            self.podman_exe = shutil.which('podman')
-        if self.podman_exe is None:
+        podman_exe: str = podman_path
+        if not podman_exe:
+            podman_exe = shutil.which('podman')
+        if podman_exe is None:
             raise errors.PodmanNotInstalled()
-        self.socket_file = socket_uri.replace('unix://', '')
+
+        self.socket_file: str = socket_uri.replace('unix://', '')
         self.proc = None
-        self.cmd = []
+
+        self.cmd: List[str] = []
         if privileged:
             self.cmd.append('sudo')
-        self.cmd = self.cmd + [
-            self.podman_exe,
-            "system",
-            "service",
-            "--time",
-            str(timeout),
-            socket_uri,
-        ]
 
-    def start(self):
+        self.cmd.append(podman_exe)
+
+        self.cmd.append(f"--log-level={logging.getLevelName(log_level).lower()}")
+
+        if os.environ.get("container") == "oci":
+            self.cmd.append("--storage-driver=vfs")
+
+        self.cmd.extend(
+            [
+                "system",
+                "service",
+                f"--time={timeout}",
+                socket_uri,
+            ]
+        )
+
+        self.log_file = tempfile.NamedTemporaryFile(
+            prefix="podman_integration_", suffix=".log", delete=False
+        )
+        self.log_file.write(f"Podman command {' '.join(self.cmd)}\n".encode())
+        self.log_file.flush()
+
+    def start(self) -> None:
         """start podman service"""
-        print("Launching {}".format(" ".join(self.cmd)))
-        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(f"Launching {' '.join(self.cmd)}\n\tLogging to {self.log_file.name}")
+        # self.proc = subprocess.Popen(self.cmd, stdout=self.log_file, stderr=self.log_file)
+        self.proc = subprocess.Popen(self.cmd)
+
         # wait for socket to be created
+        timeout = time.monotonic() + 30
         while not os.path.exists(self.socket_file):
+            if time.monotonic() > timeout:
+                raise subprocess.TimeoutExpired("podman service ", timeout)
             time.sleep(0.2)
 
-    def stop(self):
+    def stop(self) -> None:
         """stop podman service"""
         if not self.proc:
-            return (None, None)
+            return
+
         self.proc.terminate()
         try:
-            out, errs = self.proc.communicate(timeout=15)
+            return_code = self.proc.wait(timeout=15)
         except subprocess.TimeoutExpired:
             self.proc.kill()
-            out, errs = self.proc.communicate()
+            return_code = self.proc.wait()
         self.proc = None
-        if errs:
-            print(errs)
-        return (out, errs)
+
+        self.log_file.write(f"Podman service return Code: {return_code}\n".encode())
+        self.log_file.close()

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -1,0 +1,69 @@
+#   Copyright 2020 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+"""Integration Test Utils"""
+
+import shutil
+import subprocess
+import time
+import os
+import podman.tests.errors as errors
+
+
+class PodmanLauncher:
+    """Podman service launcher"""
+
+    def __init__(self, socket_uri, podman_path=None, timeout=0, privileged=False):
+        """create a launcher and build podman command"""
+        self.podman_exe = podman_path
+        if not self.podman_exe:
+            self.podman_exe = shutil.which('podman')
+        if self.podman_exe is None:
+            raise errors.PodmanNotInstalled()
+        self.socket_file = socket_uri.replace('unix://', '')
+        self.proc = None
+        self.cmd = []
+        if privileged:
+            self.cmd.append('sudo')
+        self.cmd = self.cmd + [
+            self.podman_exe,
+            "system",
+            "service",
+            "--time",
+            str(timeout),
+            socket_uri,
+        ]
+
+    def start(self):
+        """start podman service"""
+        print("Launching {}".format(" ".join(self.cmd)))
+        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # wait for socket to be created
+        while not os.path.exists(self.socket_file):
+            time.sleep(0.2)
+
+    def stop(self):
+        """stop podman service"""
+        if not self.proc:
+            return (None, None)
+        self.proc.terminate()
+        try:
+            out, errs = self.proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            out, errs = self.proc.communicate()
+        self.proc = None
+        if errs:
+            print(errs)
+        return (out, errs)

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -89,7 +89,7 @@ class TestUtilsCase(unittest.TestCase):
         mock_parent = mock_path.parent.return_value = Mock()
         mock_parent.samefile.return_value = True
 
-        actual = api.prepare_dockerfile("/work", "/work/Dockerfile")
+        actual = api.prepare_containerfile("/work", "/work/Dockerfile")
         self.assertEqual(actual, "/work/Dockerfile")
         mock_path.assert_called()
 
@@ -98,7 +98,7 @@ class TestUtilsCase(unittest.TestCase):
         mock_parent = mock_path.parent.return_value = Mock()
         mock_parent.samefile.return_value = True
 
-        actual = api.prepare_dockerfile("/work", "/work/Dockerfile")
+        actual = api.prepare_containerfile("/work", "/work/Dockerfile")
         self.assertEqual(actual, "/work/Dockerfile")
         mock_path.assert_called()
 
@@ -109,8 +109,8 @@ class TestUtilsCase(unittest.TestCase):
         with mock.patch.object(pathlib.Path, "parent") as mock_parent:
             mock_parent.samefile.return_value = False
 
-            actual = api.prepare_dockerfile("/work", "/home/Dockerfile")
-            self.assertRegex(actual, r"/work/\.dockerfile\..*")
+            actual = api.prepare_containerfile("/work", "/home/Dockerfile")
+            self.assertRegex(actual, r"\.containerfile\..*")
 
 
 if __name__ == '__main__':

--- a/podman/tests/unit/test_config.py
+++ b/podman/tests/unit/test_config.py
@@ -1,0 +1,55 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock
+
+from podman.config import PodmanConfig
+
+
+class PodmanConfigTestCase(unittest.TestCase):
+    opener = mock.mock_open(
+        read_data="""
+[containers]
+  log_size_max = -1
+  pids_limit = 2048
+  userns_size = 65536
+
+[engine]
+  num_locks = 2048
+  active_service = "testing"
+  stop_timeout = 10
+  [engine.service_destinations]
+    [engine.service_destinations.production]
+      uri = "ssh://root@localhost:22/run/podman/podman.sock"
+      identity = "/home/root/.ssh/id_rsa"
+    [engine.service_destinations.testing]
+      uri = "ssh://qe@localhost:2222/run/podman/podman.sock"
+      identity = "/home/qe/.ssh/id_rsa"
+
+[network]
+"""
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        def mocked_open(self, *args, **kwargs):
+            return PodmanConfigTestCase.opener(self, *args, **kwargs)
+
+        self.mocked_open = mocked_open
+
+    def test_connections(self):
+        with mock.patch.multiple(Path, open=self.mocked_open, exists=MagicMock(return_value=True)):
+            config = PodmanConfig("/home/developer/containers.conf")
+
+            self.assertEqual(config.active_service.id, "testing")
+            self.assertEqual(
+                config.active_service.url.geturl(), "ssh://qe@localhost:2222/run/podman/podman.sock"
+            )
+            self.assertEqual(config.services["production"].identity, Path("/home/root/.ssh/id_rsa"))
+
+            PodmanConfigTestCase.opener.assert_called_with(Path("/home/developer/containers.conf"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -20,9 +20,7 @@ FIRST_IMAGE = {
     "Size": 23855104,
     "VirtualSize": 23855104,
     "SharedSize": 0,
-    "Labels": {
-        "license": " Apache-2.0"
-    },
+    "Labels": {"license": " Apache-2.0"},
     "Containers": 2,
 }
 
@@ -126,7 +124,7 @@ class TestClientImagesManager(unittest.TestCase):
         """Unit test filters param for Images list()."""
         mock.get(
             "http+unix://localhost:9999/v3.0.0/libpod/images/json"
-            "?filters=%7B%22dangling%22%3A+%5Btrue%5D%7D",
+            "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
             json=[FIRST_IMAGE],
         )
 
@@ -177,7 +175,7 @@ class TestClientImagesManager(unittest.TestCase):
         """Unit test filters param for Images prune()."""
         mock.post(
             "http+unix://localhost:9999/v3.0.0/libpod/images/prune"
-            "?filters=%7B%22dangling%22%3A+%5Btrue%5D%7D",
+            "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
             json=[
                 {
                     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -241,7 +239,10 @@ class TestClientImagesManager(unittest.TestCase):
 
         with self.assertRaises(APIError) as e:
             _ = self.client.images.get("bad_image")
-        self.assertEqual(str(e.exception), "/images/bad_image/json")
+        self.assertEqual(
+            str(e.exception),
+            "http+unix://localhost:9999/v3.0.0/libpod/images/bad_image/json (GET operation failed)",
+        )
 
     @requests_mock.Mocker()
     def test_get_404(self, mock):
@@ -393,7 +394,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_search_filters(self, mock):
         mock.get(
             "http+unix://localhost:9999/v3.0.0/libpod/images/search"
-            "?term=fedora&noTrunc=true&filters=%7B%22stars%22%3A+%5B5%5D%7D",
+            "?filters=%7B%22stars%22%3A+%5B%225%22%5D%7D&noTrunc=True&term=fedora",
             json=[
                 {
                     "description": "mock term=fedora search",

--- a/podman/tests/unit/test_network.py
+++ b/podman/tests/unit/test_network.py
@@ -84,6 +84,7 @@ class NetworkTestCase(unittest.TestCase):
     def test_remove(self, mock):
         adapter = mock.delete(
             "http+unix://localhost:9999/v1.40/networks/podman",
+            status_code=204,
             json={"Name": "podman", "Err": None},
         )
         mock.get("http+unix://localhost:9999/v1.40/networks/podman", json=FIRST_NETWORK)

--- a/podman/tests/unit/test_networksmanager.py
+++ b/podman/tests/unit/test_networksmanager.py
@@ -192,7 +192,12 @@ class NetworksManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_create(self, mock):
-        adapter = mock.post("http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman")
+        adapter = mock.post(
+            "http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman",
+            json={
+                "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
+            },
+        )
         mock.get(
             "http+unix://localhost:9999/v1.40/networks/podman",
             json=FIRST_NETWORK,
@@ -204,6 +209,7 @@ class NetworksManagerTestCase(unittest.TestCase):
         network = self.client.networks.create(
             "podman", disabled_dns=True, enable_ipv6=False, ipam=ipam
         )
+        self.assertIsInstance(network, Network)
 
         self.assertEqual(adapter.call_count, 1)
         self.assertDictEqual(
@@ -212,8 +218,8 @@ class NetworksManagerTestCase(unittest.TestCase):
                 'DisabledDNS': True,
                 'Gateway': '172.31.255.254',
                 'IPv6': False,
-                'Range': {'IP': '172.16.0.0', 'Mask': '255.255.0.0'},
-                'Subnet': {'IP': '172.16.0.0', 'Mask': '255.240.0.0'},
+                'Range': {'IP': '172.16.0.0', 'Mask': "//8AAA=="},
+                'Subnet': {'IP': '172.16.0.0', 'Mask': "//AAAA=="},
             },
         )
 
@@ -221,7 +227,12 @@ class NetworksManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_create_defaults(self, mock):
-        adapter = mock.post("http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman")
+        adapter = mock.post(
+            "http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman",
+            json={
+                "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
+            },
+        )
         mock.get(
             "http+unix://localhost:9999/v1.40/networks/podman",
             json=FIRST_NETWORK,

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 import setuptools
 
+import podman
+
 long_description = "Python bindings to manage containers using Podman's new RESTful API."
 setuptools.setup(
     name="podman",
-    version="0.0.1",
+    version=podman.__version__,
     author="Brent Baude",
     author_email="bbaude@redhat.com",
     description="bindings for Podman V2 API",


### PR DESCRIPTION
* Update Makefile with integration target
* Update client to support unix:// and http+unix:// schemes
* Add Images integration tests
* Refactor PodmanLauncher to log service output to log file to capture debugging events.
* Add option to allow podman service to log debugging events during integration test
* Refactor Image and ImagesManager as needed now integration tests running.
* Refactor unittests where as-built differs from swagger

Included from https://github.com/containers/podman-py/pull/48:
> This change adds a base integration class and a podman launcher that can
> be used to test the api calls and their expected results. Currently the
> podman calls that will work should be ones that can be performed as
> rootless. Eventually calls that require privilege (e.g. network) can be
> implemented but skipped if the tests are not invoked as root.  It should
> be noted that all integration tests will be skipped if a podman
> executable is not in the path.

Signed-off-by: Alex Schultz <aschultz@redhat.com>
Signed-off-by: Jhon Honce <jhonce@redhat.com>