### PR TITLE
Remove tarfile.is_tarfile check in integration test

### DIFF
--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -75,7 +75,6 @@ class ContainersIntegrationTest(base.IntegrationTest):
                     fd.write(chunk)
                 fd.seek(0, 0)
 
-                self.assertTrue(tarfile.is_tarfile(name=fd))
                 with tarfile.open(fileobj=fd, mode="r") as tar:
                     contents = tar.extractfile("root/unittest").read()
                 self.assertEqual(contents, file_contents)


### PR DESCRIPTION
The test uses memory in place of writing the tarball to disk. This
causes the check to fail. It is not clear why this test ever passed.

Signed-off-by: Jhon Honce <jhonce@redhat.com>