### PR TITLE
Major cleanup and prep for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-master} HEAD)
 HEAD ?= HEAD
 
-export PODMAN_VERSION ?= '3.0.0'
+export PODMAN_VERSION ?= "3.2.0"
 
 .PHONY: podman-py
 podman-py:
@@ -56,7 +56,7 @@ uninstall:
 
 .PHONY: clean
 clean:
-	rm -rf podman.egg-info dist
+	rm -rf podman_py.egg-info dist
 	find . -depth -name __pycache__ -exec rm -rf {} \;
 	find . -depth -name \*.pyc -exec rm -f {} \;
 	$(PYTHON) ./setup.py clean --all

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# podman-py
+# podman-py [![Build Status](https://api.cirrus-ci.com/github/containers/podman-py.svg)](https://cirrus-ci.com/github/containers/podman-py/master)
 
-This python package is a set of bindings to use the new RESTful API in [libpod](https://github.com/containers/libpod).  It is currently under development and contributors are welcome!
+This python package is a library of bindings to use the RESTful API for [libpod](https://github.com/containers/podman).
+It is currently under development and contributors are welcome!
+
 
 ## Dependencies
 
-The following packages (or their distro-equivilents) are required:
-
-* `python3-coverage`
-* `python3-pylint`
-* `python3-requests`
-* `python3-requests-mock`
-* `python3-fixtures`
+* For runtime dependencies, see [requirements.txt](requirements.txt).
+* For testing and development dependencies, see [test-requirements.txt](test-requirements.txt).
 
 ## Example usage
 

--- a/podman/__init__.py
+++ b/podman/__init__.py
@@ -1,10 +1,15 @@
 """Podman client module."""
-import logging
+try:
+    from podman.api_connection import ApiConnection
+except ImportError:
 
-from podman.api_connection import ApiConnection
-from podman.client import PodmanClient, from_env
+    class ApiConnection:  # pylint: disable=too-few-public-methods
+        def __init__(self):
+            raise NotImplementedError("ApiConnection deprecated, please use PodmanClient().")
+
 
 from podman.api.version import __version__
+from podman.client import PodmanClient, from_env
 
 # isort: unique-list
 __all__ = ['ApiConnection', 'PodmanClient', '__version__', 'from_env']

--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -9,7 +9,7 @@ from podman.api.parse_utils import (
     prepare_timestamp,
     stream_frames,
 )
-from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_dockerignore
+from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_containerignore
 
 from . import version
 
@@ -33,7 +33,7 @@ __all__ = [
     'prepare_body',
     'prepare_cidr',
     'prepare_containerfile',
-    'prepare_dockerignore',
+    'prepare_containerignore',
     'prepare_filters',
     'prepare_timestamp',
     'stream_frames',

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -7,7 +7,7 @@ from requests import Response
 
 from podman import api
 from podman.api.uds import UDSAdapter
-from podman.errors.exceptions import APIError
+from podman.errors import APIError
 from podman.tlsconfig import TLSConfig
 
 _Data = Union[
@@ -38,7 +38,7 @@ class APIClient(requests.Session):
         base_url: str = None,
         version: Optional[str] = None,
         timeout: Optional[float] = None,
-        tls: Union[TLSConfig, bool] = False,
+        tls: Union[TLSConfig, bool] = False,  # pylint: disable=unused-argument
         user_agent: Optional[str] = None,
         num_pools: Optional[int] = None,
         credstore_env: Optional[Mapping[str, str]] = None,
@@ -50,8 +50,6 @@ class APIClient(requests.Session):
             ValueError: when a parameter is incorrect.
         """
         super().__init__()
-
-        _ = tls
 
         uri = urllib.parse.urlparse(base_url)
         if uri.scheme not in APIClient.supported_schemes:
@@ -80,7 +78,7 @@ class APIClient(requests.Session):
 
         self.timeout = timeout or api.DEFAULT_TIMEOUT
         self.pool_maxsize = num_pools or requests.adapters.DEFAULT_POOLSIZE
-        self.credstore_env = credstore_env or {}
+        self.credstore_env = credstore_env or dict()
 
         self.user_agent = user_agent or f"PodmanPy/{self.version}"
         self.headers.update({"User-Agent": self.user_agent})
@@ -304,7 +302,7 @@ class APIClient(requests.Session):
                 uri,
                 params=params,
                 data=data,
-                headers=(headers or {}),
+                headers=(headers or dict()),
                 timeout=timeout,
                 stream=stream,
             )

--- a/podman/api/http_utils.py
+++ b/podman/api/http_utils.py
@@ -1,9 +1,7 @@
 """Utility functions for working with URL's."""
 import collections.abc
 import json
-from typing import Dict, List, Mapping, Optional, Union, MutableMapping, Any
-
-from podman.errors import NotFound, APIError
+from typing import Dict, List, Mapping, Optional, Union, Any
 
 
 def prepare_filters(filters: Union[str, List[str], Mapping[str, str]]) -> Optional[str]:
@@ -55,7 +53,7 @@ def _format_string(filters, criteria):
     criteria[key] = [value]
 
 
-def prepare_body(body: MutableMapping[str, Any]) -> str:
+def prepare_body(body: Mapping[str, Any]) -> str:
     """Returns JSON payload to be uploaded to server.
 
     Notes:
@@ -69,7 +67,11 @@ def prepare_body(body: MutableMapping[str, Any]) -> str:
 
 
 def _filter_values(mapping: Mapping[str, Any]) -> Dict[str, Any]:
-    """Returns a canonical dictionary with values == None or empty Iterables removed."""
+    """Returns a canonical dictionary with values == None or empty Iterables removed.
+
+    Notes:
+        Dictionary is walked using recursion.
+    """
     canonical = dict()
     for key, value in mapping.items():
         # quick filter if possible...
@@ -77,12 +79,9 @@ def _filter_values(mapping: Mapping[str, Any]) -> Dict[str, Any]:
             continue
 
         # depending on type we need details...
-        if isinstance(value, collections.abc.MutableMapping):
+        if isinstance(value, collections.abc.Mapping):
             proposal = _filter_values(value)
-        elif isinstance(value, collections.abc.Set):
-            # Convert set() to list() to satisfy json encoder
-            proposal = [i for i in list(value) if i is not None]
-        elif isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
+        elif isinstance(value, collections.abc.Iterable) and not isinstance(value, str):
             proposal = [i for i in value if i is not None]
         else:
             proposal = value

--- a/podman/api/parse_utils.py
+++ b/podman/api/parse_utils.py
@@ -32,7 +32,7 @@ def parse_repository(name: str) -> Tuple[str, Optional[str]]:
 def decode_header(value: Optional[str]) -> Dict[str, Any]:
     """Decode a base64 JSON header value."""
     if value is None:
-        return {}
+        return dict()
 
     value = base64.b64decode(value)
     text = value.decode("utf-8")

--- a/podman/api/uds.py
+++ b/podman/api/uds.py
@@ -4,10 +4,17 @@ import socket
 from typing import Any, Mapping, Optional, Union
 from urllib.parse import unquote, urlparse
 
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3 import HTTPConnectionPool  # pylint: disable=import-error
-from requests.packages.urllib3.connection import HTTPConnection  # pylint: disable=import-error
-from requests.packages.urllib3.util import Timeout  # pylint: disable=import-error
+from requests.adapters import HTTPAdapter  # pylint: disable=ungrouped-imports
+
+try:
+    from urllib3 import HTTPConnectionPool
+    from urllib3.connection import HTTPConnection
+    from urllib3.util import Timeout
+except ImportError:
+    # Attempt to fallback to urllib3 that may be included with requests
+    from requests.packages.urllib3 import HTTPConnectionPool  # pylint: disable=import-error
+    from requests.packages.urllib3.connection import HTTPConnection  # pylint: disable=import-error
+    from requests.packages.urllib3.util import Timeout  # pylint: disable=import-error
 
 
 class UDSConnection(HTTPConnection):
@@ -16,7 +23,7 @@ class UDSConnection(HTTPConnection):
     def __init__(
         self,
         host: str,
-        timeout: Optional[Union[float, Timeout]] = None,
+        timeout: Union[float, Timeout, None] = None,
     ):
         """Instantiate connection to UNIX domain socket for HTTP client."""
         if isinstance(timeout, Timeout):

--- a/podman/api/version.py
+++ b/podman/api/version.py
@@ -1,3 +1,4 @@
 """Version of PodmanPy."""
-__version__ = "3.0.0"
+
+__version__ = "3.2.0"
 __compatible_version__ = "1.40"

--- a/podman/api_connection.py
+++ b/podman/api_connection.py
@@ -1,8 +1,9 @@
-""" Provides a Connection to a Podman service. """
+""" Provides a Connection to a Podman service."""
 import json
 import logging
 import socket
 import urllib.parse
+import warnings
 from contextlib import AbstractContextManager
 from http import HTTPStatus
 from http.client import HTTPConnection
@@ -32,6 +33,7 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
             )
         self.uri = uri
         self.base = base
+        warnings.warn("APIConnection() and supporting classes.", PendingDeprecationWarning)
 
     def connect(self):
         """Connect to the URL given when initializing class"""

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -6,8 +6,7 @@ from typing import Generator, Iterator, List, Union
 
 from podman.domain.containers import Container
 from podman.domain.images import Image
-from podman.errors import ImageNotFound
-from podman.errors.exceptions import ContainerError
+from podman.errors import ContainerError, ImageNotFound
 
 logger = logging.getLogger("podman.containers")
 
@@ -18,7 +17,7 @@ class RunMixin:  # pylint: disable=too-few-public-methods
     def run(
         self,
         image: Union[str, Image],
-        command: Union[str, List[str]] = None,
+        command: Union[str, List[str], None] = None,
         stdout=True,
         stderr=False,
         remove: bool = False,

--- a/podman/domain/events.py
+++ b/podman/domain/events.py
@@ -1,5 +1,6 @@
 """Model and Manager for Event resources."""
 import json
+import logging
 from datetime import datetime
 from typing import Any, Dict, Optional, Union
 
@@ -8,6 +9,8 @@ import requests
 from podman import api
 from podman.api.client import APIClient
 from podman.errors import APIError
+
+logger = logging.getLogger("podman.events")
 
 
 class EventsManager:  # pylint: disable=too-few-public-methods

--- a/podman/domain/images.py
+++ b/podman/domain/images.py
@@ -6,7 +6,7 @@ import requests
 
 from podman import api
 from podman.domain.manager import PodmanResource
-from podman.errors.exceptions import APIError, ImageNotFound
+from podman.errors import APIError, ImageNotFound
 
 logger = logging.getLogger("podman.images")
 
@@ -55,17 +55,14 @@ class Image(PodmanResource):
     def save(
         self,
         chunk_size: Optional[int] = api.DEFAULT_CHUNK_SIZE,
-        named: Union[str, bool] = False,
+        named: Union[str, bool] = False,  # pylint: disable=unused-argument
     ) -> Iterator[bytes]:
         """Returns Image as tarball.
 
         Args:
             chunk_size: If None, data will be streamed in received buffer size.
                 If not None, data will be returned in sized buffers. Default: 2MB
-            named: When False, tarball will not retain repository and tag information.
-                When True, first tag is used to identify the Image.
-                when str, value is used as tag to identify the Image.
-                Always ignored.
+            named: Ignored.
 
         Raises:
             APIError: when service returns an error.
@@ -73,8 +70,6 @@ class Image(PodmanResource):
         Notes:
             Format is set to docker-archive, this allows load() to import this tarball.
         """
-        _ = named
-
         response = self.client.get(
             f"/images/{self.id}/get", params={"format": ["docker-archive"]}, stream=True
         )
@@ -85,13 +80,18 @@ class Image(PodmanResource):
         body = response.json()
         raise APIError(body["cause"], response=response, explanation=body["message"])
 
-    def tag(self, repository: str, tag: Optional[str], force: bool = False) -> bool:
+    def tag(
+        self,
+        repository: str,
+        tag: Optional[str],
+        force: bool = False,  # pylint: disable=unused-argument
+    ) -> bool:
         """Tag Image into repository.
 
         Args:
             repository: The repository for tagging Image.
             tag: optional tag name.
-            force: force tagging. Always ignored.
+            force: Ignored.
 
         Returns:
             True, when operational succeeds.
@@ -100,12 +100,7 @@ class Image(PodmanResource):
             ImageNotFound: when service cannot find image.
             APIError: when service returns an error.
         """
-        _ = force
-
-        params = {"repo": repository}
-        if tag is not None:
-            params["tag"] = tag
-
+        params = {"repo": repository, "tag": tag}
         response = self.client.post(f"/images/{self.id}/tag", params=params)
 
         if response.status_code == requests.codes.created:

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -13,7 +13,7 @@ import requests
 
 from podman import api
 from podman.domain.images import Image
-from podman.errors.exceptions import APIError, BuildError, PodmanError
+from podman.errors import APIError, BuildError, PodmanError
 
 logger = logging.getLogger("podman.images")
 
@@ -88,7 +88,7 @@ class BuildMixin:
             # The Dockerfile will be copied into the context_dir if needed
             params["dockerfile"] = api.prepare_containerfile(kwargs["path"], params["dockerfile"])
 
-            excludes = api.prepare_dockerignore(kwargs["path"])
+            excludes = api.prepare_containerignore(kwargs["path"])
             body = api.create_tar(
                 anchor=kwargs["path"], exclude=excludes, gzip=kwargs.get("gzip", False)
             )

--- a/podman/domain/manager.py
+++ b/podman/domain/manager.py
@@ -1,7 +1,7 @@
 """Base classes for PodmanResources and Manager's."""
 from abc import ABC, abstractmethod
 from collections import abc
-from typing import Any, ClassVar, List, Optional, Type, TypeVar, Union, Mapping
+from typing import Any, List, Mapping, Optional, Type, TypeVar, Union
 
 from podman.api.client import APIClient
 
@@ -70,13 +70,12 @@ class PodmanResource(ABC):
 
 
 class Manager(ABC):
-    """Base class for representing a Manager of resources for a Podman service.
+    """Base class for representing a Manager of resources for a Podman service."""
 
-    Attributes:
-        resource: Subclass of PodmanResource this manager will operate upon.
-    """
-
-    resource: ClassVar[Type[PodmanResource]] = None
+    @property
+    @abstractmethod
+    def resource(self) -> Type[PodmanResource]:
+        """Subclass of PodmanResource the factory prepare_model() will create."""
 
     def __init__(self, client: APIClient = None) -> None:
         """Initialize Manager() object.
@@ -94,17 +93,14 @@ class Manager(ABC):
         Note:
             This method does _not_ provide any mutex mechanism.
         """
-        raise NotImplementedError()
 
     @abstractmethod
     def get(self, key: str) -> PodmanResourceType:
         """Returns representation of resource."""
-        raise NotImplementedError()
 
     @abstractmethod
     def list(self, **kwargs) -> List[PodmanResourceType]:
         """Returns list of resources."""
-        raise NotImplementedError()
 
     def prepare_model(self, attrs: Union[PodmanResource, Mapping[str, Any]]) -> PodmanResourceType:
         """ Create a model from a set of attributes. """

--- a/podman/domain/networks.py
+++ b/podman/domain/networks.py
@@ -7,6 +7,7 @@ Note:
     """
 import hashlib
 import json
+import logging
 from contextlib import suppress
 from typing import List, Optional, Union
 
@@ -15,6 +16,8 @@ import requests
 from podman.domain.containers import Container
 from podman.domain.manager import PodmanResource
 from podman.errors import APIError
+
+logger = logging.getLogger("podman.networks")
 
 
 class Network(PodmanResource):

--- a/podman/domain/pods_manager.py
+++ b/podman/domain/pods_manager.py
@@ -5,13 +5,12 @@ Notes:
 """
 import json
 import logging
-from typing import Dict, List, Optional, Type, ClassVar, Any
+from typing import Any, Dict, List, Optional, Type
 
 import requests
 
 from podman import api
-from podman.api import APIClient
-from podman.domain.manager import Manager
+from podman.domain.manager import Manager, PodmanResource
 from podman.domain.pods import Pod
 from podman.errors import APIError, NotFound
 
@@ -19,13 +18,11 @@ logger = logging.getLogger("podman.pods")
 
 
 class PodsManager(Manager):
-    """Specialized Manager for Pod resources.
+    """Specialized Manager for Pod resources."""
 
-    Attributes:
-        resource: Pod subclass of PodmanResource, factory method `prepare_model` will create these.
-    """
-
-    resource: ClassVar[Type[Pod]] = Pod
+    @property
+    def resource(self) -> Type[PodmanResource]:
+        return Pod
 
     def create(self, name: str, **kwargs) -> Pod:
         """Create a Pod.
@@ -100,10 +97,7 @@ class PodsManager(Manager):
         if response.status_code != requests.codes.okay:
             raise APIError(body["cause"], response=response, explanation=body["message"])
 
-        pods: List[Pod] = list()
-        for item in body:
-            pods.append(self.prepare_model(attrs=item))
-        return pods
+        return [self.prepare_model(attrs=i) for i in body]
 
     def prune(self, filters: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """Delete unused Pods.

--- a/podman/domain/registry_data.py
+++ b/podman/domain/registry_data.py
@@ -1,10 +1,13 @@
 """Module for tracking registry metadata."""
+import logging
 from typing import Any, Mapping, Optional, Union
 
 from podman import api
 from podman.domain.images import Image
 from podman.domain.manager import PodmanResource
-from podman.errors.exceptions import InvalidArgument
+from podman.errors import InvalidArgument
+
+logger = logging.getLogger("podman.images")
 
 
 class RegistryData(PodmanResource):
@@ -30,7 +33,7 @@ class RegistryData(PodmanResource):
 
     @property
     def id(self) -> Optional[str]:
-        return self.attrs.get("Id", None)
+        return self.attrs.get("Id")
 
     @property
     def short_id(self):

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -1,10 +1,13 @@
 """SystemManager to provide system level information from Podman service."""
+import logging
 from typing import Any, Dict, Optional
 
 import requests
 
 from podman.api.client import APIClient
 from podman.errors import APIError
+
+logger = logging.getLogger("podman.system")
 
 
 class SystemManager:

--- a/podman/domain/volumes.py
+++ b/podman/domain/volumes.py
@@ -1,12 +1,10 @@
 """Model and Manager for Volume resources."""
-import json
 import logging
-from typing import Any, Dict, List, Optional, Type, ClassVar
+from typing import Any, Dict, List, Optional, Type
 
 import requests
 
 from podman import api
-from podman.api.client import APIClient
 from podman.domain.manager import Manager, PodmanResource
 from podman.errors import APIError, NotFound
 
@@ -47,14 +45,11 @@ class Volume(PodmanResource):
 
 
 class VolumesManager(Manager):
-    """Specialized Manager for Volume resources.
+    """Specialized Manager for Volume resources."""
 
-    Attributes:
-        resource: Volume subclass of PodmanResource, factory method `prepare_model` will
-            create these.
-    """
-
-    resource: ClassVar[Type[Volume]] = Volume
+    @property
+    def resource(self) -> Type[PodmanResource]:
+        return Volume
 
     def create(self, name: Optional[str] = None, **kwargs) -> Volume:
         """Create a Volume.
@@ -131,14 +126,11 @@ class VolumesManager(Manager):
         if response.status_code == requests.codes.not_found:
             return []
 
-        data = response.json()
+        body = response.json()
         if response.status_code != requests.codes.okay:
-            raise APIError(data["cause"], response=response, explanation=data["message"])
+            raise APIError(body["cause"], response=response, explanation=body["message"])
 
-        volumes: List[Volume] = list()
-        for item in data:
-            volumes.append(self.prepare_model(item))
-        return volumes
+        return [self.prepare_model(i) for i in body]
 
     def prune(
         self, filters: Optional[Dict[str, str]] = None  # pylint: disable=unused-argument

--- a/podman/errors/__init__.py
+++ b/podman/errors/__init__.py
@@ -1,29 +1,62 @@
 """errors for Podman API.
 
-Notes:
-    See exceptions.py for APIClient errors.
+    Notes:
+        'importlib' exceptions are used to differentiate between APIConnection and PodmanClient
+            Errors. Therefore, installing both APIConnection and PodmanClient is not supported.
+            PodmanClient related errors take precedence over APIConnection ones.
 """
+import warnings
 from http.client import HTTPException
 
-from .exceptions import APIError, ImageNotFound, NotFound
-
 # isort: unique-list
-__all__ = ['APIError', 'ImageNotFound', 'NotFound']
+__all__ = [
+    'APIError',
+    'BuildError',
+    'ContainerError',
+    'DockerException',
+    'ImageNotFound',
+    'InvalidArgument',
+    'NotFound',
+    'NotFoundError',
+    'PodmanError',
+]
+
+try:
+    from .exceptions import (
+        APIError,
+        BuildError,
+        ContainerError,
+        DockerException,
+        InvalidArgument,
+        NotFound,
+        PodmanError,
+    )
+except ImportError:
+    pass
 
 
 class NotFoundError(HTTPException):
-    """HTTP request returned a http.HTTPStatus.NOT_FOUND."""
+    """HTTP request returned a http.HTTPStatus.NOT_FOUND.
+
+    Notes:
+        TODO Delete when APIConnection EOL.
+    """
 
     def __init__(self, message, response=None):
         super().__init__(message)
         self.response = response
+        warnings.warn("APIConnection() and supporting classes.", PendingDeprecationWarning)
 
 
-# TODO this collision needs resolved.
-class ImageNotFound(NotFoundError):  # pylint: disable=function-redefined
-    """HTTP request returned a http.HTTPStatus.NOT_FOUND.
-    Specialized for Image not found.
-    """
+# If found, use new ImageNotFound otherwise old class
+try:
+    from .exceptions import ImageNotFound
+except ImportError:
+
+    class ImageNotFound(NotFoundError):
+        """HTTP request returned a http.HTTPStatus.NOT_FOUND.
+        Specialized for Image not found.
+        """
 
 
 class NetworkNotFound(NotFoundError):
@@ -54,6 +87,7 @@ class RequestError(HTTPException):
     def __init__(self, message, response=None):
         super().__init__(message)
         self.response = response
+        warnings.warn("APIConnection() and supporting classes.", PendingDeprecationWarning)
 
 
 class InternalServerError(HTTPException):
@@ -62,3 +96,4 @@ class InternalServerError(HTTPException):
     def __init__(self, message, response=None):
         super().__init__(message)
         self.response = response
+        warnings.warn("APIConnection() and supporting classes.", PendingDeprecationWarning)

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -1,0 +1,5 @@
+"""PodmanPy Tests."""
+
+# Do not auto-update these as test code should be changed to reflect changes in Podman API
+BASE_URL = "http+unix://localhost:9999/v3.2.0"
+BASE_SOCK = "unix://localhost:9999"

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -20,7 +20,7 @@ import unittest
 import podman.tests.integration.base as base
 from podman import PodmanClient
 from podman.domain.images import Image
-from podman.errors.exceptions import ImageNotFound, APIError
+from podman.errors import ImageNotFound, APIError
 
 
 # @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')

--- a/podman/tests/integration/test_manifests.py
+++ b/podman/tests/integration/test_manifests.py
@@ -2,7 +2,7 @@ import unittest
 from contextlib import suppress
 
 from podman import PodmanClient
-from podman.errors.exceptions import APIError, ImageNotFound, NotFound
+from podman.errors import APIError, ImageNotFound
 from podman.tests.integration import base
 
 # @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')

--- a/podman/tests/integration/test_pods.py
+++ b/podman/tests/integration/test_pods.py
@@ -2,7 +2,7 @@ import unittest
 import random
 
 from podman import PodmanClient
-from podman.errors.exceptions import NotFound
+from podman.errors import NotFound
 from podman.tests.integration import base
 
 

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -6,9 +6,9 @@ from unittest.mock import patch
 
 import requests_mock
 
-from podman import PodmanClient, api
+from podman import PodmanClient, api, tests
 from podman.domain.images import Image
-from podman.errors.exceptions import BuildError, DockerException
+from podman.errors import BuildError, DockerException
 
 
 class TestBuildCase(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestBuildCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -55,7 +55,7 @@ class TestBuildCase(unittest.TestCase):
 
         with requests_mock.Mocker() as mock:
             mock.post(
-                "http+unix://localhost:9999/v3.0.0/libpod/build"
+                tests.BASE_URL + "/libpod/build"
                 "?t=latest"
                 "&buildargs=%7B%22BUILD_DATE%22%3A+%22January+1%2C+1970%22%7D"
                 "&cpuperiod=10"
@@ -64,7 +64,7 @@ class TestBuildCase(unittest.TestCase):
                 text=buffer.getvalue(),
             )
             mock.get(
-                "http+unix://localhost:9999/v3.0.0/libpod/images/032b8b2855fc/json",
+                tests.BASE_URL + "/libpod/images/032b8b2855fc/json",
                 json={
                     "Id": "032b8b2855fc",
                     "ParentId": "",
@@ -114,7 +114,7 @@ class TestBuildCase(unittest.TestCase):
 
         with requests_mock.Mocker() as mock:
             mock.post(
-                "http+unix://localhost:9999/v3.0.0/libpod/build",
+                tests.BASE_URL + "/libpod/build",
                 text=buffer.getvalue(),
             )
 
@@ -124,13 +124,13 @@ class TestBuildCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_build_no_context(self, mock):
-        mock.post("http+unix://localhost:9999/v3.0.0/libpod/images/build")
+        mock.post(tests.BASE_URL + "/libpod/images/build")
         with self.assertRaises(TypeError):
             self.client.images.build()
 
     @requests_mock.Mocker()
     def test_build_encoding(self, mock):
-        mock.post("http+unix://localhost:9999/v3.0.0/libpod/images/build")
+        mock.post(tests.BASE_URL + "/libpod/images/build")
         with self.assertRaises(DockerException):
             self.client.images.build(path="/root", gzip=True, encoding="utf-8")
 

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -1,10 +1,10 @@
 import unittest
-from collections import Iterable, Iterator
+from collections import Iterator
 from unittest.mock import patch, DEFAULT
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.containers import Container
 from podman.domain.containers_manager import ContainersManager
 from podman.errors import NotFound
@@ -33,7 +33,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -47,7 +47,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers"
+            tests.BASE_URL + "/libpod/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -62,7 +62,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_404(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers"
+            tests.BASE_URL + "/libpod/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json={
                 "cause": "Container not found.",
@@ -80,7 +80,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_empty(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/json",
+            tests.BASE_URL + "/libpod/containers/json",
             text="[]",
         )
         actual = self.client.containers.list()
@@ -89,7 +89,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/json",
+            tests.BASE_URL + "/libpod/containers/json",
             json=[FIRST_CONTAINER, SECOND_CONTAINER],
         )
         actual = self.client.containers.list()
@@ -105,7 +105,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_filtered(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/json?"
+            tests.BASE_URL + "/libpod/containers/json?"
             "all=True"
             "&filters=%7B"
             "%22before%22%3A"
@@ -133,7 +133,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_no_filters(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/json",
+            tests.BASE_URL + "/libpod/containers/json",
             json=[FIRST_CONTAINER, SECOND_CONTAINER],
         )
         actual = self.client.containers.list()
@@ -149,7 +149,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/prune",
+            tests.BASE_URL + "/libpod/containers/prune",
             json=[
                 {
                     "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -176,7 +176,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/create",
+            tests.BASE_URL + "/libpod/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -184,7 +184,7 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers"
+            tests.BASE_URL + "/libpod/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -203,7 +203,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_run_detached(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/create",
+            tests.BASE_URL + "/libpod/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -211,12 +211,12 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/"
+            tests.BASE_URL + "/libpod/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start",
             status_code=204,
         )
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers"
+            tests.BASE_URL + "/libpod/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -231,7 +231,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_run(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/create",
+            tests.BASE_URL + "/libpod/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -239,12 +239,12 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers/"
+            tests.BASE_URL + "/libpod/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start",
             status_code=204,
         )
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/containers"
+            tests.BASE_URL + "/libpod/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )

--- a/podman/tests/unit/test_events.py
+++ b/podman/tests/unit/test_events.py
@@ -5,7 +5,7 @@ from types import GeneratorType
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.events import EventsManager
 
 
@@ -13,7 +13,7 @@ class EventsManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -44,9 +44,7 @@ class EventsManagerTestCase(unittest.TestCase):
             buffer.write(json.JSONEncoder().encode(item))
             buffer.write("\n")
 
-        adapter = mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/events", text=buffer.getvalue()
-        )
+        adapter = mock.get(tests.BASE_URL + "/libpod/events", text=buffer.getvalue())
 
         manager = EventsManager(client=self.client.api)
         actual = manager.list(decode=True)

--- a/podman/tests/unit/test_image.py
+++ b/podman/tests/unit/test_image.py
@@ -3,8 +3,8 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
-from podman.domain.images_manager import ImagesManager
+from podman import PodmanClient, tests
+from podman.domain.images import Image
 
 FIRST_IMAGE = {
     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -39,21 +39,17 @@ class ImageTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
 
         self.client.close()
 
-    def test_podmanclient(self):
-        manager = self.client.images
-        self.assertIsInstance(manager, ImagesManager)
-
     @requests_mock.Mocker()
     def test_history(self, mock):
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images"
+        adapter = mock.get(
+            tests.BASE_URL + "/libpod/images"
             "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/history",
             json=[
                 {
@@ -66,25 +62,19 @@ class ImageTestCase(unittest.TestCase):
                 }
             ],
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images"
-            "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
-            json=FIRST_IMAGE,
-        )
+        image = Image(attrs=FIRST_IMAGE, client=self.client.api)
 
-        image = self.client.images.get(
-            "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
-        )
         history = image.history()
         self.assertEqual(history[0]["Id"], image.id)
+        self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_reload(self, mock):
         update = FIRST_IMAGE.copy()
         update["Containers"] = 0
 
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images"
+        adapter = mock.get(
+            tests.BASE_URL + "/libpod/images"
             "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             [
                 {"json": FIRST_IMAGE},
@@ -99,6 +89,7 @@ class ImageTestCase(unittest.TestCase):
 
         image.reload()
         self.assertEqual(image.attrs["Containers"], 0)
+        self.assertTrue(adapter.call_count, 2)
 
     @requests_mock.Mocker()
     def test_save(self, mock):
@@ -106,25 +97,18 @@ class ImageTestCase(unittest.TestCase):
         tarball = b'Yet another weird tarball...'
         body = io.BytesIO(tarball)
 
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images"
-            "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
-            json=FIRST_IMAGE,
-        )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images/"
+        adapter = mock.get(
+            tests.BASE_URL + "/libpod/images/"
             "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/get",
             body=body,
         )
-
-        image = self.client.images.get(
-            "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
-        )
+        image = Image(attrs=FIRST_IMAGE, client=self.client.api)
 
         with io.BytesIO() as fd:
             for chunk in image.save():
                 fd.write(chunk)
             self.assertEqual(fd.getbuffer(), tarball)
+        self.assertTrue(adapter.called_once)
 
 
 if __name__ == '__main__':

--- a/podman/tests/unit/test_manager.py
+++ b/podman/tests/unit/test_manager.py
@@ -1,6 +1,5 @@
 import unittest
 
-from podman.domain.manager import Manager
 from podman.domain.pods_manager import PodsManager
 
 

--- a/podman/tests/unit/test_manifests.py
+++ b/podman/tests/unit/test_manifests.py
@@ -1,6 +1,6 @@
 import unittest
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.manifests import ManifestsManager, Manifest
 
 
@@ -8,7 +8,7 @@ class ManifestTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/podman/tests/unit/test_networksmanager.py
+++ b/podman/tests/unit/test_networksmanager.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.ipam import IPAMConfig, IPAMPool
 from podman.domain.networks import Network
 from podman.domain.networks_manager import NetworksManager
@@ -111,7 +111,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -138,7 +138,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_libpod(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/networks/podman/json",
+            tests.BASE_URL + "/libpod/networks/podman/json",
             json=FIRST_NETWORK_LIBPOD,
         )
 
@@ -171,7 +171,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_libpod(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/networks/json",
+            tests.BASE_URL + "/libpod/networks/json",
             json=FIRST_NETWORK_LIBPOD + SECOND_NETWORK_LIBPOD,
         )
 
@@ -193,7 +193,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman",
+            tests.BASE_URL + "/libpod/networks/create?name=podman",
             json={
                 "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
             },
@@ -228,7 +228,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_defaults(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/networks/create?name=podman",
+            tests.BASE_URL + "/libpod/networks/create?name=podman",
             json={
                 "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
             },
@@ -256,7 +256,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune_libpod(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/networks/prune",
+            tests.BASE_URL + "/libpod/networks/prune",
             json=[
                 {"Name": "podman", "Error": None},
                 {"Name": "database", "Error": None},

--- a/podman/tests/unit/test_pod.py
+++ b/podman/tests/unit/test_pod.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.pods import Pod
 from podman.errors import NotFound
 
@@ -16,7 +16,7 @@ class PodTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -35,29 +35,22 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_kill(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/kill",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.kill()
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_kill_404(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/kill",
             status_code=404,
             json={
@@ -66,44 +59,31 @@ class PodTestCase(unittest.TestCase):
                 "response": 404,
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         with self.assertRaises(NotFound):
             pod.kill()
+        self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_pause(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/pause",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.pause()
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_pause_404(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/pause",
             status_code=404,
             json={
@@ -112,103 +92,69 @@ class PodTestCase(unittest.TestCase):
                 "response": 404,
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         with self.assertRaises(NotFound):
             pod.pause()
+        self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_remove(self, mock):
         adapter = mock.delete(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods/"
+            tests.BASE_URL + "/libpod/pods/"
             "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8?force=True",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.remove(force=True)
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_restart(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/restart",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.restart()
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_start(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/start",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.start()
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_stop(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/stop?t=70.0",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.stop(timeout=70.0)
         self.assertTrue(adapter.called_once)
 
@@ -231,45 +177,29 @@ class PodTestCase(unittest.TestCase):
             ],
             "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
         }
-
         adapter = mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/top"
             "?ps_args=aux&stream=False",
             json=body,
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
 
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         actual = pod.top(ps_args="aux")
-        self.assertTrue(adapter.called_once)
         self.assertDictEqual(actual, body)
+        self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
     def test_unpause(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/unpause",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             },
         )
-        mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
-            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-            json=FIRST_POD,
-        )
-        pod = self.client.pods.get(
-            "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-        )
-
+        pod = Pod(attrs=FIRST_POD, client=self.client.api)
         pod.unpause()
         self.assertTrue(adapter.called_once)
 

--- a/podman/tests/unit/test_podmanclient.py
+++ b/podman/tests/unit/test_podmanclient.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 
 
 class TestPodmanClient(unittest.TestCase):
@@ -11,7 +11,7 @@ class TestPodmanClient(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.client = PodmanClient(base_url='unix://localhost:9999')
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     @mock.patch('requests.Session.close')
     def test_close(self, mock_close):
@@ -27,7 +27,7 @@ class TestPodmanClient(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get("http+unix://localhost:9999/v3.0.0/libpod/system/info", json=body)
+        mock.get(tests.BASE_URL + "/libpod/system/info", json=body)
 
         with PodmanClient(base_url="http+unix://localhost:9999") as client:
             actual = client.info()

--- a/podman/tests/unit/test_podsmanager.py
+++ b/podman/tests/unit/test_podsmanager.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.pods import Pod
 from podman.domain.pods_manager import PodsManager
 from podman.errors import NotFound
@@ -21,7 +21,7 @@ class PodsManagerTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -35,12 +35,12 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods/create",
+            tests.BASE_URL + "/libpod/pods/create",
             json={"Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"},
             status_code=201,
         )
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
             json=FIRST_POD,
         )
@@ -54,7 +54,7 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods"
+            tests.BASE_URL + "/libpod/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
             json=FIRST_POD,
         )
@@ -66,29 +66,27 @@ class PodsManagerTestCase(unittest.TestCase):
             actual.id, "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
         )
 
-        @requests_mock.Mocker()
-        def test_get404(self, mock):
-            mock.get(
-                "http+unix://localhost:9999/v3.0.0/libpod/pods"
-                "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
-                status_code=404,
-                json={
-                    "cause": "no such pod",
-                    "message": "no pod with name or ID "
-                    "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-                    " found: no such pod",
-                    "response": 404,
-                },
-            )
+    @requests_mock.Mocker()
+    def test_get404(self, mock):
+        mock.get(
+            tests.BASE_URL + "/libpod/pods"
+            "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
+            status_code=404,
+            json={
+                "cause": "no such pod",
+                "message": "no pod with name or ID "
+                "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
+                " found: no such pod",
+                "response": 404,
+            },
+        )
 
-            with self.assertRaises(NotFound):
-                self.client.pods.get(
-                    "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
-                )
+        with self.assertRaises(NotFound):
+            self.client.pods.get("c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8")
 
     @requests_mock.Mocker()
     def test_list(self, mock):
-        mock.get("http+unix://localhost:9999/v3.0.0/libpod/pods/json", json=[FIRST_POD, SECOND_POD])
+        mock.get(tests.BASE_URL + "/libpod/pods/json", json=[FIRST_POD, SECOND_POD])
 
         actual = self.client.pods.list()
 
@@ -102,7 +100,7 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         adapter = mock.post(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods/prune",
+            tests.BASE_URL + "/libpod/pods/prune",
             json=[
                 {
                     "Err": None,
@@ -146,7 +144,7 @@ class PodsManagerTestCase(unittest.TestCase):
             "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
         }
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/pods/stats"
+            tests.BASE_URL + "/libpod/pods/stats"
             "?namesOrIDs=c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             json=body,
         )

--- a/podman/tests/unit/test_registrydata.py
+++ b/podman/tests/unit/test_registrydata.py
@@ -2,10 +2,10 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.images_manager import ImagesManager
 from podman.domain.registry_data import RegistryData
-from podman.errors.exceptions import InvalidArgument
+from podman.errors import InvalidArgument
 
 FIRST_IMAGE = {
     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -36,7 +36,7 @@ class RegistryDataTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -46,7 +46,7 @@ class RegistryDataTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_init(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/images/"
+            tests.BASE_URL + "/libpod/images/"
             "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )

--- a/podman/tests/unit/test_secrets.py
+++ b/podman/tests/unit/test_secrets.py
@@ -1,6 +1,6 @@
 import unittest
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.secrets import SecretsManager
 
 
@@ -8,7 +8,7 @@ class SecretsTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/podman/tests/unit/test_system.py
+++ b/podman/tests/unit/test_system.py
@@ -2,14 +2,14 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 
 
 class SystemTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -34,7 +34,7 @@ class SystemTestCase(unittest.TestCase):
         }
 
         mock.get(
-            "http+unix://localhost:9999/v3.0.0/libpod/system/df",
+            tests.BASE_URL + "/libpod/system/df",
             json=body,
         )
 
@@ -49,14 +49,14 @@ class SystemTestCase(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get("http+unix://localhost:9999/v3.0.0/libpod/system/info", json=body)
+        mock.get(tests.BASE_URL + "/libpod/system/info", json=body)
 
         actual = self.client.info()
         self.assertDictEqual(actual, body)
 
     @requests_mock.Mocker()
     def test_ping(self, mock):
-        mock.head("http+unix://localhost:9999/v3.0.0/libpod/_ping")
+        mock.head(tests.BASE_URL + "/libpod/_ping")
         self.assertTrue(self.client.ping())
 
     @requests_mock.Mocker()
@@ -67,7 +67,7 @@ class SystemTestCase(unittest.TestCase):
             "Arch": "amd64",
             "Os": "linux",
         }
-        mock.get("http+unix://localhost:9999/v3.0.0/libpod/version", json=body)
+        mock.get(tests.BASE_URL + "/libpod/version", json=body)
         self.assertDictEqual(self.client.version(), body)
 
 

--- a/podman/tests/unit/test_volume.py
+++ b/podman/tests/unit/test_volume.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests_mock
 
-from podman import PodmanClient
+from podman import PodmanClient, tests
 from podman.domain.volumes import Volume
 
 FIRST_VOLUME = {
@@ -19,7 +19,7 @@ class VolumeTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = PodmanClient(base_url="http+unix://localhost:9999")
+        self.client = PodmanClient(base_url=tests.BASE_SOCK)
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -32,13 +32,8 @@ class VolumeTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_remove(self, mock):
-        adapter = mock.delete(
-            "http+unix://localhost:9999/v3.0.0/libpod/volumes/dbase?force=True", status_code=204
-        )
-
-        mock.get("http+unix://localhost:9999/v3.0.0/libpod/volumes/dbase", json=FIRST_VOLUME)
-        volume = self.client.volumes.get("dbase")
-
+        adapter = mock.delete(tests.BASE_URL + "/libpod/volumes/dbase?force=True", status_code=204)
+        volume = Volume(attrs=FIRST_VOLUME, client=self.client.api)
         volume.remove(force=True)
         self.assertTrue(adapter.called_once)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,9 @@ exclude = '''
 [tool.isort]
 profile = "black"
 line_length = 100
-
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.24
 toml>=0.10.2
+urllib3~=1.26.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[metadata]
+name = podman-py
+version = attr: podman.__version__
+author = Brent Baude, Jhon Honce
+author_email = jhonce@redhat.com
+description = Bindings for Podman RESTful API
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/containers/podman-py
+license =  Apache-2.0
+license_file =  LICENSE
+platforms = any
+project_urls =
+    Bug Tracker = https://github.com/containers/podman-py/issues
+    Libpod API = https://docs.podman.io/en/latest/_static/api.html
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development :: Libraries :: Python Modules
+keywords = podman, libpod
+
+[options]
+include_package_data = True
+python_requires = >=3.6
+test_suite =
+install_requires =
+    requests>=2.24
+    toml>=0.10.2
+    urllib3~=1.26.4
+
+[bdist_wheel]
+universal = true
+
+[sdist]
+formats = zip

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,33 @@
 import setuptools
 
-import podman
+import fnmatch
+from setuptools import find_packages
+from setuptools.command.build_py import build_py as build_py_orig
 
-long_description = "Python bindings to manage containers using Podman's new RESTful API."
+excluded = [
+    "podman/api_connection.py",
+    "podman/containers/*",
+    "podman/images/*",
+    "podman/manifests/*",
+    "podman/networks/*",
+    "podman/pods/*",
+    "podman/system/*",
+    "podman/system/*",
+    "podman/tests/*",
+]
+
+
+class build_py(build_py_orig):
+    def find_package_modules(self, package, package_dir):
+        modules = super().find_package_modules(package, package_dir)
+        return [
+            (pkg, mod, file)
+            for (pkg, mod, file) in modules
+            if not any(fnmatch.fnmatchcase(file, pat=pattern) for pattern in excluded)
+        ]
+
+
 setuptools.setup(
-    name="podman",
-    version=podman.__version__,
-    author="Brent Baude",
-    author_email="bbaude@redhat.com",
-    description="bindings for Podman V2 API",
-    long_description=long_description,
-    url="https://github.com/containers/podman-py",
-    packages=setuptools.find_packages(),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-    ],
-    python_requires='>=3.6',
+    packages=find_packages(),
+    cmdclass={"build_py": build_py},
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-fixtures
-nose
-coverage
-pylint
 black
+coverage
+fixtures~=3.0.0
+nose
+pylint
 requests-mock


### PR DESCRIPTION
* Update Version to 3.2.0
* Map podman.errors.exceptions to podman.errors to be more compatible
* Speed up unit tests, removed unnecessary mocking
* Change Manager.resource to an abtractproperty resulting in better
  error messages when subclasses forget to set resource
* Rewrote for loops into list comprehensions where possible
* Deprecation warnings added for APIConnection
* setup.cfg introduced to hold static configuration
* setup.py refactored to filter out tests, APIConnection, and supporting
  files
* Corrected directory name in Makefile target clean
* Added build-system to pyproject.toml
* Added hidden dependency urllib3 to requirements

Signed-off-by: Jhon Honce <jhonce@redhat.com>