### PR TITLE
Updates for publishing to PyPi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ export PODMAN_VERSION ?= "3.2.0"
 
 .PHONY: podman-py
 podman-py:
+	rm dist/* || :
+	pip install wheel
 	PODMAN_VERSION=$(PODMAN_VERSION) \
-	$(PYTHON) setup.py sdist bdist
+	$(PYTHON) setup.py sdist bdist bdist_wheel
 
 .PHONY: lint
 lint:
@@ -34,6 +36,16 @@ unittest:
 integration:
 	coverage run -m unittest discover -s podman/tests/integration
 	coverage report -m --skip-covered --fail-under=80 --omit=./podman/tests/* --omit=.tox/* --omit=/usr/lib/*
+
+.PHONY: upload
+upload:
+	twine upload --verbose -r testpypi dist/*whl dist/*zip
+	# pip install -i https://test.pypi.org/simple/ podman-py
+
+.PHONY: release
+release:
+	twine upload --verbose dist/*whl dist/*zip
+	# pip install podman-py
 
 # .PHONY: install
 HEAD ?= HEAD

--- a/README.md
+++ b/README.md
@@ -1,42 +1,47 @@
 # podman-py [![Build Status](https://api.cirrus-ci.com/github/containers/podman-py.svg)](https://cirrus-ci.com/github/containers/podman-py/master)
 
-This python package is a library of bindings to use the RESTful API for [libpod](https://github.com/containers/podman).
+This python package is a library of bindings to use the RESTful API for [Podman](https://github.com/containers/podman).
 It is currently under development and contributors are welcome!
 
 
 ## Dependencies
 
-* For runtime dependencies, see [requirements.txt](requirements.txt).
-* For testing and development dependencies, see [test-requirements.txt](test-requirements.txt).
+* For runtime dependencies, see [requirements.txt](https://github.com/containers/podman-py/blob/master/requirements.txt).
+* For testing and development dependencies, see [test-requirements.txt](https://github.com/containers/podman-py/blob/master/test-requirements.txt).
 
 ## Example usage
 
 ```python
-
+"""Demonstrate PodmanClient."""
+import json
 from podman import PodmanClient
 
 # Provide a URI path for the libpod service.  In libpod, the URI can be a unix
 # domain socket(UDS) or TCP.  The TCP connection has not been implemented in this
 # package yet.
 
-uri = "unix://localhost/run/podman/podman.sock"
+uri = "unix:///run/user/1000/podman/podman.sock"
 
 with PodmanClient(uri) as client:
-    print("version: ", client.version())
+    version = client.version()
+    print("Release: ", version["Version"])
+    print("Compatible API: ", version["ApiVersion"])
+    print("Podman API: ", version["Components"][0]["Details"]["APIVersion"], "\n")
+
     # get all images
-    images = client.images.list()
-    # print the first one
-    print(images[0])
+    for image in client.images.list():
+        print(image, image.id, "\n")
+
     # find all containers
-    containers = client.containers.list()
-    # assuming there is at least one
-    first_name = containers[0]['Names'][0]
-    # inspect that one
-    container = client.containers.get(first_name)
-    print(container)
-    # available fields
-    print(sorted(container.attrs.keys()))
-    client.images.remove(images.id)
+    for container in client.containers.list():
+        first_name = container['Names'][0]
+        container = client.containers.get(first_name)
+        print(container, container.id, "\n")
+
+        # available fields
+        print(sorted(container.attrs.keys()))
+
+    print(json.dumps(client.df(), indent=4))
 ```
 
 ## Contributing

--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -1,4 +1,6 @@
 """Tools for connecting to a Podman service."""
+import re
+
 from podman.api.client import APIClient
 from podman.api.http_utils import prepare_body, prepare_filters
 from podman.api.parse_utils import (
@@ -16,13 +18,24 @@ from . import version
 DEFAULT_TIMEOUT: float = 60.0
 DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024
 
-API_VERSION: str = version.__version__
-COMPATIBLE_VERSION: str = version.__compatible_version__
+
+def _api_version(release: str, significant: int = 3) -> str:
+    """Return API version removing any additional identifiers from the release version.
+
+    Notes:
+        This is a simple lexicographical parsing, no semantics are applied, e.g. semver checking."""
+    items = re.split(r"\.|-|\+", release)
+    parts = items[0:significant]
+    return ".".join(parts)
+
+
+VERSION: str = _api_version(version.__version__)
+COMPATIBLE_VERSION: str = _api_version(version.__compatible_version__, 2)
 
 # isort: unique-list
 __all__ = [
     'APIClient',
-    'API_VERSION',
+    'VERSION',
     'COMPATIBLE_VERSION',
     'DEFAULT_CHUNK_SIZE',
     'DEFAULT_TIMEOUT',

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -71,7 +71,7 @@ class APIClient(requests.Session):
         if uri.scheme == "http+unix":
             self.mount(uri.scheme, UDSAdapter())
 
-        self.version = version or api.API_VERSION
+        self.version = version or api.VERSION
         self.path_prefix = f"/v{self.version}/libpod"
         self.compatible_version = kwargs.get("compatible_version") or api.COMPATIBLE_VERSION
         self.compatible_prefix = f"/v{self.compatible_version}"

--- a/podman/api/version.py
+++ b/podman/api/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "3.2.0"
+__version__ = "3.1.1.3"
 __compatible_version__ = "1.40"

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -37,7 +37,7 @@ class SystemManager:
 
     def info(self, *_, **__) -> Dict[str, Any]:
         """Returns information on Podman service."""
-        response = self.client.get("/system/info")
+        response = self.client.get("/info")
         body = response.json()
 
         if response.status_code == requests.codes.okay:

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -1,5 +1,5 @@
 """PodmanPy Tests."""
 
 # Do not auto-update these as test code should be changed to reflect changes in Podman API
-BASE_URL = "http+unix://localhost:9999/v3.2.0"
+BASE_URL = "http+unix://localhost:9999/v3.1.1"
 BASE_SOCK = "unix://localhost:9999"

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -118,7 +118,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             # See https://github.com/containers/podman/pull/9892 for the service
             #   side fix requires podman >= 3.2
             # processes = [i.strip() for i in report["Processes"][0]]
-            self.assertIn("/usr/bin/top", report["Processes"][0])
+            self.assertIn("/usr/bin/top", report["Processes"][0][-1])
 
             top_ctnr.stop()
             top_ctnr.reload()

--- a/podman/tests/integration/test_system.py
+++ b/podman/tests/integration/test_system.py
@@ -14,34 +14,33 @@
 #
 """system call integration tests"""
 
-from podman import system
-from podman.api_connection import ApiConnection
+from podman import system, PodmanClient
 import podman.tests.integration.base as base
 
 
-class TestSystem(base.IntegrationTest):
+class SystemIntegrationTest(base.IntegrationTest):
     """system call integration test"""
 
     def setUp(self):
         super().setUp()
-        self.api = ApiConnection(self.socket_uri)
-        self.addCleanup(self.api.close)
+        self.client = PodmanClient(base_url=self.socket_uri)
+        self.addCleanup(self.client.close)
 
     def test_info(self):
         """integration: system info call"""
-        output = system.info(self.api)
+        output = self.client.info()
         self.assertTrue('host' in output)
 
     def test_version(self):
         """integration: system version call"""
-        output = system.version(self.api)
+        output = self.client.version()
         self.assertTrue('Platform' in output)
         self.assertTrue('Version' in output)
         self.assertTrue('ApiVersion' in output)
 
     def test_show_disk_usage(self):
         """integration: system disk usage call"""
-        output = system.show_disk_usage(self.api)
+        output = self.client.df()
         self.assertTrue('Images' in output)
         self.assertTrue('Containers' in output)
         self.assertTrue('Volumes' in output)

--- a/podman/tests/unit/test_podmanclient.py
+++ b/podman/tests/unit/test_podmanclient.py
@@ -27,7 +27,7 @@ class TestPodmanClient(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get(tests.BASE_URL + "/libpod/system/info", json=body)
+        mock.get(tests.BASE_URL + "/libpod/info", json=body)
 
         with PodmanClient(base_url="http+unix://localhost:9999") as client:
             actual = client.info()

--- a/podman/tests/unit/test_system.py
+++ b/podman/tests/unit/test_system.py
@@ -3,6 +3,7 @@ import unittest
 import requests_mock
 
 from podman import PodmanClient, tests
+from podman.domain.system import SystemManager
 
 
 class SystemTestCase(unittest.TestCase):
@@ -49,7 +50,7 @@ class SystemTestCase(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get(tests.BASE_URL + "/libpod/system/info", json=body)
+        mock.get(tests.BASE_URL + "/libpod/info", json=body)
 
         actual = self.client.info()
         self.assertDictEqual(actual, body)

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ install_requires =
     urllib3~=1.26.4
 
 [bdist_wheel]
-universal = true
+# python < 3.6 not supported
+universal = false
 
 [sdist]
 formats = zip


### PR DESCRIPTION
* Update demo in README.md
* Fix links in README.md
* Provide mapping for release version (podman.__version__) vs. API version
  (api.VERSION)
* Fix /libpod/info endpoint tests
* Add upload and release targets to Makefile
* Build python3 wheel file for publication
* Port system integration tests to PodmanClient()

Signed-off-by: Jhon Honce <jhonce@redhat.com>