### PR TITLE
Finish transport adapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export PODMAN_VERSION ?= "3.2.0"
 .PHONY: podman-py
 podman-py:
 	rm dist/* || :
-	pip install wheel
+	pip install wheel pyxdg
 	PODMAN_VERSION=$(PODMAN_VERSION) \
 	$(PYTHON) setup.py sdist bdist bdist_wheel
 

--- a/contrib/cirrus/latest_podman.sh
+++ b/contrib/cirrus/latest_podman.sh
@@ -2,6 +2,14 @@
 
 set -xeo pipefail
 
+systemctl enable sshd
+systemctl start sshd
+systemctl status sshd ||:
+
+ssh-keygen -t ecdsa -b 521 -f /root/.ssh/id_ecdsa -P ""
+cp /root/.ssh/authorized_keys /root/.ssh/authorized_keys%
+cat /root/.ssh/id_ecdsa.pub >>/root/.ssh/authorized_keys
+
 mkdir -p "$GOPATH/src/github.com/containers/"
 cd "$GOPATH/src/github.com/containers/"
 

--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -1,6 +1,7 @@
 """Tools for connecting to a Podman service."""
 import re
 
+from podman.api.cached_property import cached_property
 from podman.api.client import APIClient
 from podman.api.http_utils import prepare_body, prepare_filters
 from podman.api.parse_utils import (
@@ -15,7 +16,6 @@ from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_cont
 
 from . import version
 
-DEFAULT_TIMEOUT: float = 60.0
 DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024
 
 
@@ -36,10 +36,10 @@ COMPATIBLE_VERSION: str = _api_version(version.__compatible_version__, 2)
 # isort: unique-list
 __all__ = [
     'APIClient',
-    'VERSION',
     'COMPATIBLE_VERSION',
     'DEFAULT_CHUNK_SIZE',
-    'DEFAULT_TIMEOUT',
+    'VERSION',
+    'cached_property',
     'create_tar',
     'decode_header',
     'frames',

--- a/podman/api/adapter_utils.py
+++ b/podman/api/adapter_utils.py
@@ -1,0 +1,50 @@
+"""Utility functions for working with Adapters."""
+from typing import NamedTuple, Mapping
+
+
+def _key_normalizer(key_class: NamedTuple, request_context: Mapping) -> Mapping:
+    """Create a pool key out of a request context dictionary.
+
+    According to RFC 3986, both the scheme and host are case-insensitive.
+    Therefore, this function normalizes both before constructing the pool
+    key for an HTTPS request. If you wish to change this behaviour, provide
+    alternate callables to ``key_fn_by_scheme``.
+
+    Args:
+        key_class: The class to use when constructing the key. This should be a namedtuple
+            with the scheme and host keys at a minimum.
+        request_context: An object that contain the context for a request.
+
+    Returns:
+        A namedtuple that can be used as a connection pool key.
+
+    Notes:
+        Copied from urllib3.poolmanager._default_key_normalizer.
+    """
+    # Since we mutate the dictionary, make a copy first
+    context = request_context.copy()
+    context["scheme"] = context["scheme"].lower()
+    context["host"] = context["host"].lower()
+
+    # These are both dictionaries and need to be transformed into frozensets
+    for key in ("headers", "_proxy_headers", "_socks_options"):
+        if key in context and context[key] is not None:
+            context[key] = frozenset(context[key].items())
+
+    # The socket_options key may be a list and needs to be transformed into a
+    # tuple.
+    socket_opts = context.get("socket_options")
+    if socket_opts is not None:
+        context["socket_options"] = tuple(socket_opts)
+
+    # Map the kwargs to the names in the namedtuple - this is necessary since
+    # namedtuples can't have fields starting with '_'.
+    for key in list(context.keys()):
+        context["key_" + key] = context.pop(key)
+
+    # Default to ``None`` for keys missing from the context
+    for field in key_class._fields:
+        if field not in context:
+            context[field] = None
+
+    return key_class(**context)

--- a/podman/api/cached_property.py
+++ b/podman/api/cached_property.py
@@ -1,0 +1,9 @@
+"""Provide cached_property for Python <=3.8 programs."""
+import functools
+
+try:
+    from functools import cached_property  # pylint: disable=unused-import
+except ImportError:
+
+    def cached_property(fn):
+        return property(functools.lru_cache()(fn))

--- a/podman/api/http_utils.py
+++ b/podman/api/http_utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for working with URL's."""
+"""Utility functions for working with URLs."""
 import collections.abc
 import json
 from typing import Dict, List, Mapping, Optional, Union, Any

--- a/podman/api/ssh.py
+++ b/podman/api/ssh.py
@@ -1,75 +1,300 @@
-"""Place holder for future adapter to allow remote access via ssh tunnel.
+"""Specialized Transport Adapter for remote Podman access via ssh tunnel.
 
 See Podman go bindings for more details.
 """
-from typing import Any, Mapping, Optional, Union
-from urllib.parse import urlparse
+import collections
+import functools
+import http.client
+import logging
+import pathlib
+import random
+import socket
+import subprocess
+import time
+import urllib.parse
+from contextlib import suppress
+from typing import Optional, Union
 
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3 import HTTPConnectionPool  # pylint: disable=import-error
-from requests.packages.urllib3.connection import HTTPConnection  # pylint: disable=import-error
-from requests.packages.urllib3.util import Timeout  # pylint: disable=import-error
+import xdg.BaseDirectory
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_RETRIES, HTTPAdapter
+
+try:
+    import urllib3
+except ImportError:
+    import requests.packages.urllib3 as urllib3
+
+from .adapter_utils import _key_normalizer
+
+logger = logging.getLogger("podman.ssh_adapter")
 
 
-class SSHConnection(HTTPConnection):
-    """Specialization of HTTPConnection to use a ssh tunnel."""
+class SSHSocket(socket.socket):
+    """Specialization of socket.socket to forward a UNIX domain socket via SSH."""
+
+    def __init__(self, uri: str, identity: Optional[str] = None):
+        """Initialize SSHSocket.
+
+        Args:
+            uri: Full address of a Podman service including path to remote socket.
+            identity: path to file containing SSH key for authorization
+
+        Examples:
+            SSHSocket("http+ssh://alice@api.example:2222/run/user/1000/podman/podman.sock",
+                      "~alice/.ssh/api_ed25519"
+            )
+        """
+        super().__init__(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.uri = uri
+        self.identity = identity
+        self._proc: Optional[subprocess.Popen] = None
+
+        runtime_dir = pathlib.Path(xdg.BaseDirectory.get_runtime_dir(strict=False)) / "podman"
+        runtime_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        self.local_sock = runtime_dir / f"podman-forward-{random.getrandbits(80):x}.sock"
+
+    def connect(self, **kwargs):  # pylint: disable=unused-argument
+        """Returns socket for SSH tunneled UNIX domain socket.
+
+        Raises:
+            subprocess.TimeoutExpired: when SSH client fails to create local socket
+        """
+        uri = urllib.parse.urlparse(self.uri)
+
+        command = [
+            "ssh",
+            "-N",
+            "-L",
+            f"{self.local_sock}:{uri.path}",
+        ]
+
+        if self.identity is not None:
+            path = pathlib.Path(self.identity).expanduser()
+            command += ["-i", str(path)]
+
+        command += [f"ssh://{uri.netloc}"]
+        self._proc = subprocess.Popen(
+            command,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+        )
+
+        expiration = time.monotonic() + 300
+        while not self.local_sock.exists():
+            if time.monotonic() > expiration:
+                cmd = " ".join(command)
+                raise subprocess.TimeoutExpired(cmd, expiration)
+
+            logger.debug("Waiting on %s", self.local_sock)
+            time.sleep(0.2)
+
+        super().connect(str(self.local_sock))
+
+    def send(self, data: bytes, flags=None) -> int:  # pylint: disable=unused-argument
+        """Write data to SSH forwarded UNIX domain socket.
+
+        Args:
+            data: Data to write.
+            flags: Ignored.
+
+        Returns:
+            The number of bytes written.
+
+        Raises:
+            RuntimeError: When socket has not been connected.
+        """
+        if not self._proc or self._proc.stdin.closed:
+            raise RuntimeError(f"SSHSocket({self.uri}) not connected.")
+
+        count = self._proc.stdin.write(data)
+        self._proc.stdin.flush()
+        return count
+
+    def recv(self, buffersize, flags=None) -> bytes:  # pylint: disable=unused-argument
+        """Read data from SSH forwarded UNIX domain socket.
+
+        Args:
+            buffersize: Maximum number of bytes to read.
+            flags: Ignored.
+
+        Raises:
+            RuntimeError: When socket has not been connected.
+        """
+        if not self._proc:
+            raise RuntimeError(f"SSHSocket({self.uri}) not connected.")
+        return self._proc.stdout.read(buffersize)
+
+    def close(self):
+        """Release resources held by SSHSocket.
+
+        Notes:
+            - SSH client is first sent SIGTERM, then a SIGKILL 20 seconds later if needed.
+        """
+        if not self._proc or self._proc.stdin.closed:
+            return
+
+        with suppress(BrokenPipeError):
+            self._proc.stdin.close()
+        self._proc.stdout.close()
+
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            logger.debug("SIGKILL required to stop SSH client.")
+            self._proc.kill()
+
+        self.local_sock.unlink()
+        self._proc = None
+        super().close()
+
+
+class SSHConnection(http.client.HTTPConnection):
+    """Specialization of HTTPConnection to use a SSH forwarded socket."""
 
     def __init__(
         self,
         host: str,
-        timeout: Optional[Union[float, Timeout]] = None,
-    ):
-        """Instantiate connection to ssh tunnel for Podman service for HTTP client."""
-        _ = host
-        _ = timeout
-        raise NotImplementedError
-
-    def connect(self):
-        """Returns socket for ssh tunnel."""
-        raise NotImplementedError
-
-    def __del__(self):
-        """Cleanup connection."""
-        raise NotImplementedError
-
-
-class SSHConnectionPool(HTTPConnectionPool):
-    """Specialization of urllib3 HTTPConnectionPool for ssh tunnels."""
-
-    # pylint: disable=too-few-public-methods
-
-    def __init__(
-        self,
-        host: str,
-        timeout: Optional[Union[float, Timeout]] = None,
+        port: int,
+        timeout: Union[float, urllib3.Timeout, None] = None,
+        strict=False,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> None:
-        if isinstance(timeout, float):
-            timeout = Timeout.from_float(timeout)
-        _ = host
+        """Initialize connection to SSHSocket for HTTP client.
 
-    def _new_conn(self) -> SSHConnection:
-        return SSHConnection(self.host, self.timeout)
+        Args:
+            host: Ignored.
+            port: Ignored.
+            timeout: Time to allow for operation.
+            strict: Ignored.
+
+        Keyword Args:
+            uri: Full address of a Podman service including path to remote socket. Required.
+            identity: path to file containing SSH key for authorization.
+        """
+        self.sock: Optional[socket.socket] = None
+
+        connection_kwargs = kwargs.copy()
+        connection_kwargs["port"] = port
+
+        if timeout is not None:
+            if isinstance(timeout, urllib3.Timeout):
+                try:
+                    connection_kwargs["timeout"] = float(timeout.total)
+                except TypeError:
+                    pass
+            connection_kwargs["timeout"] = timeout
+
+        self.uri = connection_kwargs.pop("uri")
+        self.identity = connection_kwargs.pop("identity", None)
+
+        super().__init__(host, **connection_kwargs)
+        if logger.getEffectiveLevel() == logging.DEBUG:
+            self.set_debuglevel(1)
+
+    def connect(self) -> None:
+        """Connect to Podman service via SSHSocket."""
+        sock = SSHSocket(self.uri, self.identity)
+        sock.settimeout(self.timeout)
+        sock.connect()
+        self.sock = sock
+
+
+class SSHConnectionPool(urllib3.HTTPConnectionPool):
+    """Specialized HTTPConnectionPool for holding SSH connections."""
+
+    ConnectionCls = SSHConnection
+
+
+class SSHPoolManager(urllib3.PoolManager):
+    """Specialized PoolManager for tracking SSH connections."""
+
+    # pylint's special handling for namedtuple does not cover this usage
+    # pylint: disable=invalid-name
+    _PoolKey = collections.namedtuple(
+        "_PoolKey", urllib3.poolmanager.PoolKey._fields + ("key_uri", "key_identity")
+    )
+
+    # Map supported schemes to Pool Classes
+    pool_classes_by_scheme = {
+        "http": SSHConnectionPool,
+        "http+ssh": SSHConnectionPool,
+    }
+
+    # Map supported schemes to Pool Key index generator
+    key_fn_by_scheme = {
+        "http": functools.partial(_key_normalizer, _PoolKey),
+        "http+ssh": functools.partial(_key_normalizer, _PoolKey),
+    }
+
+    def __init__(self, num_pools=10, headers=None, **kwargs):
+        """Initialize SSHPoolManager.
+
+        Args:
+            num_pools: Number of SSH Connection pools to maintain.
+            headers: Additional headers to add to operations.
+        """
+        super().__init__(num_pools, headers, **kwargs)
+        self.pool_classes_by_scheme = SSHPoolManager.pool_classes_by_scheme
+        self.key_fn_by_scheme = SSHPoolManager.key_fn_by_scheme
 
 
 class SSHAdapter(HTTPAdapter):
-    """Specialization of requests transport adapter for ssh tunnels."""
+    """Specialization of requests transport adapter for SSH forwarded UNIX domain sockets."""
 
-    # Abstract methods (get_connection) are specialized and pylint cannot walk hierarchy.
-    # pylint: disable=arguments-differ
-    # pylint: disable=too-few-public-methods
+    def __init__(
+        self,
+        uri: str,
+        pool_connections: int = 9,
+        pool_maxsize: int = 10,
+        max_retries: int = DEFAULT_RETRIES,
+        pool_block: int = DEFAULT_POOLBLOCK,
+        **kwargs,
+    ):
+        """Initialize SSHAdapter.
 
-    def __init__(self, *args, **kwargs):
-        self.timeout = None
+        Args:
+            uri: Full address of a Podman service including path to remote socket.
+                Format, ssh://<user>@<host>[:port]/run/podman/podman.sock?secure=True
+            pool_connections: The number of connection pools to cache. Should be at least one less
+                than pool_maxsize.
+            pool_maxsize: The maximum number of connections to save in the pool.
+                OpenSSH default is 10.
+            max_retries: The maximum number of retries each connection should attempt.
+            pool_block: Whether the connection pool should block for connections.
+
+        Keyword Args:
+            timeout (float):
+            identity (str): Optional path to ssh identity key
+        """
+        self.poolmanager: Optional[SSHPoolManager] = None
+
+        # Parsed for fail-fast side effects
+        _ = urllib.parse.urlparse(uri)
+        self._pool_kwargs = {"uri": uri}
+
+        if "identity" in kwargs:
+            path = pathlib.Path(kwargs.get("identity"))
+            if not path.exists():
+                raise FileNotFoundError(f"Identity file '{path}' does not exist.")
+            self._pool_kwargs["identity"] = str(path)
+
         if "timeout" in kwargs:
-            self.timeout = kwargs.pop("timeout")
+            self._pool_kwargs["timeout"] = kwargs.get("timeout")
 
-        super().__init__(*args, **kwargs)
+        super().__init__(pool_connections, pool_maxsize, max_retries, pool_block)
 
-    def get_connection(self, host, proxies: Mapping[str, Any] = None) -> SSHConnectionPool:
-        """Returns ssh tunneled connection to Podman service."""
-        if len(proxies) > 0:
-            uri = urlparse(host)
-            if uri.scheme in proxies:
-                raise ValueError(f"{self.__class__.__name__} does not support proxies.")
+    def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, **kwargs):
+        """Initialize SSHPoolManager to be used by SSHAdapter.
 
-        return SSHConnectionPool(host, timeout=self.timeout)
+        Args:
+            connections: The number of urllib3 connection pools to cache.
+            maxsize: The maximum number of connections to save in the pool.
+            block: Block when no free connections are available.
+        """
+        pool_kwargs = kwargs.copy()
+        pool_kwargs.update(self._pool_kwargs)
+        self.poolmanager = SSHPoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )

--- a/podman/api/ssh.py
+++ b/podman/api/ssh.py
@@ -64,6 +64,8 @@ class SSHSocket(socket.socket):
         command = [
             "ssh",
             "-N",
+            "-o",
+            "StrictHostKeyChecking no",
             "-L",
             f"{self.local_sock}:{uri.path}",
         ]

--- a/podman/api/tar_utils.py
+++ b/podman/api/tar_utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for working with tarball's."""
+"""Utility functions for working with tarballs."""
 import pathlib
 import random
 import shutil

--- a/podman/api/version.py
+++ b/podman/api/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "3.1.1.3"
+__version__ = "3.1.2.1"
 __compatible_version__ = "1.40"

--- a/podman/config.py
+++ b/podman/config.py
@@ -1,8 +1,6 @@
 """Read containers.conf file."""
 import os
-import pathlib
 import urllib.parse
-from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -10,6 +8,8 @@ try:
     import toml
 except ImportError:
     import pytoml as toml
+
+from podman.api import cached_property
 
 
 class ServiceConnection:
@@ -36,17 +36,15 @@ class ServiceConnection:
         """Returns identifier for service connection."""
         return self.name
 
-    @property
-    @lru_cache(1)
+    @cached_property
     def url(self) -> urllib.parse.ParseResult:
         """Returns URL for service connection."""
         return urllib.parse.urlparse(self.attrs.get("uri"))
 
-    @property
-    @lru_cache(1)
+    @cached_property
     def identity(self) -> Path:
         """Returns Path to identity file for service connection."""
-        return pathlib.Path(self.attrs.get("identity"))
+        return Path(self.attrs.get("identity"))
 
 
 class PodmanConfig:
@@ -59,7 +57,7 @@ class PodmanConfig:
             home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home()))
             self.path = home / ".config" / "containers" / "containers.conf"
         else:
-            self.path = pathlib.Path(path)
+            self.path = Path(path)
 
         self.attrs = dict()
         if self.path.exists():
@@ -76,12 +74,11 @@ class PodmanConfig:
         return False
 
     @property
-    def id(self):  # pylint: disable=invalid-name
+    def id(self) -> Path:  # pylint: disable=invalid-name
         """Returns Path() of container.conf."""
         return self.path
 
-    @property
-    @lru_cache(1)
+    @cached_property
     def services(self) -> Dict[str, ServiceConnection]:
         """Returns list of service connections."""
         services: Dict[str, ServiceConnection] = dict()
@@ -95,8 +92,7 @@ class PodmanConfig:
 
         return services
 
-    @property
-    @lru_cache(1)
+    @cached_property
     def active_service(self) -> Optional[ServiceConnection]:
         """Returns active connection."""
 

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -333,16 +333,12 @@ class Container(PodmanResource):
         Keyword Args:
             timeout (int): Seconds to wait for container to stop before killing container.
         """
-        connection_timeout = api.DEFAULT_TIMEOUT
+        params = {"timeout": kwargs.get("timeout")}
+        post_kwargs = dict()
+        if kwargs.get("timeout"):
+            post_kwargs["timeout"] = float(params["timeout"]) * 1.5
 
-        params = dict()
-        if "timeout" in kwargs:
-            params = {"timeout": kwargs["timeout"]}
-            connection_timeout += float(kwargs["timeout"])
-
-        response = self.client.post(
-            f"/containers/{self.id}/restart", params=params, timeout=connection_timeout
-        )
+        response = self.client.post(f"/containers/{self.id}/restart", params=params, **post_kwargs)
         response.raise_for_status()
 
     def start(self, **kwargs) -> None:
@@ -408,13 +404,11 @@ class Container(PodmanResource):
         """
         params = {"all": kwargs.get("all"), "timeout": kwargs.get("timeout")}
 
-        connection_timeout: float = api.DEFAULT_TIMEOUT
-        if params.get("timeout"):
-            connection_timeout += float(params["timeout"])
+        post_kwargs = dict()
+        if kwargs.get("timeout"):
+            post_kwargs["timeout"] = float(params["timeout"]) * 1.5
 
-        response = self.client.post(
-            f"/containers/{self.id}/stop", params=params, timeout=connection_timeout
-        )
+        response = self.client.post(f"/containers/{self.id}/stop", params=params, **post_kwargs)
         response.raise_for_status()
 
         if response.status_code == requests.codes.no_content:
@@ -474,7 +468,7 @@ class Container(PodmanResource):
         Keyword Args:
             condition (str): Container state on which to release, values:
                 not-running (default), next-exit or removed.
-            timeout (int): Number of seconds to wait for the container to stop.
+            timeout (int): Ignored.
 
         Returns:
             Keys:

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -92,7 +92,10 @@ class BuildMixin:
                 anchor=kwargs["path"], exclude=excludes, gzip=kwargs.get("gzip", False)
             )
 
-        timeout = kwargs.get("timeout", api.DEFAULT_TIMEOUT)
+        post_kwargs = dict()
+        if kwargs.get("timeout"):
+            post_kwargs["timeout"] = float(kwargs.get("timeout"))
+
         response = self.client.post(
             "/build",
             params=params,
@@ -102,7 +105,7 @@ class BuildMixin:
                 # "X-Registry-Config": "TODO",
             },
             stream=True,
-            timeout=timeout,
+            **post_kwargs,
         )
         if hasattr(body, "close"):
             body.close()

--- a/podman/domain/volumes.py
+++ b/podman/domain/volumes.py
@@ -6,7 +6,7 @@ import requests
 
 from podman import api
 from podman.domain.manager import Manager, PodmanResource
-from podman.errors import APIError, NotFound
+from podman.errors import APIError
 
 logger = logging.getLogger("podman.volumes")
 
@@ -126,9 +126,7 @@ class VolumesManager(Manager):
         """
         response = self.client.post("/volumes/prune")
         data = response.json()
-
-        if response.status_code != requests.codes.okay:
-            raise APIError(data["cause"], response=response, explanation=data["message"])
+        response.raise_for_status()
 
         volumes: List[str] = list()
         space_reclaimed = 0
@@ -160,11 +158,4 @@ class VolumesManager(Manager):
         if isinstance(name, Volume):
             name = name.name
         response = self.client.delete(f"/volumes/{name}", params={"force": force})
-
-        if response.status_code == requests.codes.no_content:
-            return
-
-        data = response.json()
-        if response.status_code == requests.codes.not_found:
-            raise NotFound(data["cause"], response=response, explanation=data["message"])
-        raise APIError(data["cause"], response=response, explanation=data["message"])
+        response.raise_for_status()

--- a/podman/errors/__init__.py
+++ b/podman/errors/__init__.py
@@ -19,7 +19,6 @@ __all__ = [
     'NotFound',
     'NotFoundError',
     'PodmanError',
-    'SwarmNotImplementedError',
 ]
 
 try:
@@ -31,7 +30,6 @@ try:
         InvalidArgument,
         NotFound,
         PodmanError,
-        SwarmNotImplementedError,
     )
 except ImportError:
     pass

--- a/podman/errors/exceptions.py
+++ b/podman/errors/exceptions.py
@@ -8,13 +8,17 @@ from requests.exceptions import HTTPError
 # Break circular import
 if typing.TYPE_CHECKING:
     from podman.domain.containers import Container
+    from podman.api.client import APIResponse
 
 
 class APIError(HTTPError):
     """A wrapper for HTTP errors from the API."""
 
     def __init__(
-        self, message: str, response: Optional[Response] = None, explanation: Optional[str] = None
+        self,
+        message: str,
+        response: Union[Response, "APIResponse", None] = None,
+        explanation: Optional[str] = None,
     ):
         """Create an APIError.
 
@@ -144,13 +148,3 @@ class ContainerError(PodmanError):
 
 class InvalidArgument(PodmanError):
     """Parameter to method/function was not valid."""
-
-
-class SwarmNotImplementedError(NotImplementedError):
-    """Raises on attempted swarm operations."""
-
-    def __init__(self, message: Optional[str] = None):
-        if message is None:
-            super().__init__("Swarm operations are not supported by Podman service.")
-            return
-        super().__init__(message)

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -1,5 +1,7 @@
 """PodmanPy Tests."""
 
-# Do not auto-update these as test code should be changed to reflect changes in Podman API
-BASE_URL = "http+unix://localhost:9999/v3.1.1"
-BASE_SOCK = "unix://localhost:9999"
+# Do not auto-update these from version.py,
+#   as test code should be changed to reflect changes in Podman API versions
+BASE_SOCK = "unix:///run/api.sock"
+LIBPOD_URL = "http://%2Frun%2Fapi.sock/v3.1.2/libpod"
+COMPATIBLE_URL = "http://%2Frun%2Fapi.sock/v1.40"

--- a/podman/tests/integration/test_adapters.py
+++ b/podman/tests/integration/test_adapters.py
@@ -1,0 +1,53 @@
+import getpass
+import os
+import unittest
+
+import time
+
+from podman import PodmanClient
+from podman.tests.integration import base, utils
+
+
+class AdapterIntegrationTest(base.IntegrationTest):
+    def setUp(self):
+        super().setUp()
+
+    def test_ssh_ping(self):
+        with PodmanClient(
+            base_url=f"http+ssh://{getpass.getuser()}@localhost:22{self.socket_file}"
+        ) as client:
+            self.assertTrue(client.ping())
+
+        with PodmanClient(
+            base_url=f"ssh://{getpass.getuser()}@localhost:22{self.socket_file}"
+        ) as client:
+            self.assertTrue(client.ping())
+
+    def test_unix_ping(self):
+        with PodmanClient(base_url=f"unix://{self.socket_file}") as client:
+            self.assertTrue(client.ping())
+
+        with PodmanClient(base_url=f"http+unix://{self.socket_file}") as client:
+            self.assertTrue(client.ping())
+
+    def test_tcp_ping(self):
+        podman = utils.PodmanLauncher(
+            "tcp:localhost:8889",
+            podman_path=base.IntegrationTest.podman,
+            log_level=self.log_level,
+        )
+        try:
+            podman.start(check_socket=False)
+            time.sleep(0.5)
+
+            with PodmanClient(base_url=f"tcp:localhost:8889") as client:
+                self.assertTrue(client.ping())
+
+            with PodmanClient(base_url=f"http://localhost:8889") as client:
+                self.assertTrue(client.ping())
+        finally:
+            podman.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -75,7 +75,7 @@ class PodmanLauncher:
         )
         self.version = str(process.stdout.decode("utf-8")).strip().split()[2]
 
-    def start(self) -> None:
+    def start(self, check_socket=True) -> None:
         """start podman service"""
         logger.info(
             "Launching(%s) %s refid=%s",
@@ -94,6 +94,9 @@ class PodmanLauncher:
 
         self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         threading.Thread(target=consume_lines, args=[self.proc.stdout, consume]).start()
+
+        if not check_socket:
+            return
 
         # wait for socket to be created
         timeout = time.monotonic() + 30

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -55,7 +55,7 @@ class TestBuildCase(unittest.TestCase):
 
         with requests_mock.Mocker() as mock:
             mock.post(
-                tests.BASE_URL + "/libpod/build"
+                tests.LIBPOD_URL + "/build"
                 "?t=latest"
                 "&buildargs=%7B%22BUILD_DATE%22%3A+%22January+1%2C+1970%22%7D"
                 "&cpuperiod=10"
@@ -64,7 +64,7 @@ class TestBuildCase(unittest.TestCase):
                 text=buffer.getvalue(),
             )
             mock.get(
-                tests.BASE_URL + "/libpod/images/032b8b2855fc/json",
+                tests.LIBPOD_URL + "/images/032b8b2855fc/json",
                 json={
                     "Id": "032b8b2855fc",
                     "ParentId": "",
@@ -114,7 +114,7 @@ class TestBuildCase(unittest.TestCase):
 
         with requests_mock.Mocker() as mock:
             mock.post(
-                tests.BASE_URL + "/libpod/build",
+                tests.LIBPOD_URL + "/build",
                 text=buffer.getvalue(),
             )
 
@@ -124,13 +124,13 @@ class TestBuildCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_build_no_context(self, mock):
-        mock.post(tests.BASE_URL + "/libpod/images/build")
+        mock.post(tests.LIBPOD_URL + "/images/build")
         with self.assertRaises(TypeError):
             self.client.images.build()
 
     @requests_mock.Mocker()
     def test_build_encoding(self, mock):
-        mock.post(tests.BASE_URL + "/libpod/images/build")
+        mock.post(tests.LIBPOD_URL + "/images/build")
         with self.assertRaises(DockerException):
             self.client.images.build(path="/root", gzip=True, encoding="utf-8")
 

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -32,7 +32,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove(self, mock):
         adapter = mock.delete(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd?v=True&force=True",
             status_code=204,
         )
@@ -44,7 +44,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_rename(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/rename",
             status_code=204,
         )
@@ -64,7 +64,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_restart(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/restart?timeout=10",
             status_code=204,
         )
@@ -75,7 +75,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_start_dkeys(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start"
             "?detachKeys=%5Ef%5Eu",
             status_code=204,
@@ -87,7 +87,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_start(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start",
             status_code=204,
         )
@@ -115,7 +115,7 @@ class ContainersTestCase(unittest.TestCase):
             buffer.write("\n")
 
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/stats"
+            tests.LIBPOD_URL + "/containers/stats"
             "?containers=87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd"
             "&stream=True",
             text=buffer.getvalue(),
@@ -137,7 +137,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_stop(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/stop"
             "?all=True&timeout=10.0",
             status_code=204,
@@ -149,7 +149,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_stop_304(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/stop",
             json={
                 "cause": "container already stopped",
@@ -166,7 +166,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_unpause(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/unpause",
             status_code=204,
         )
@@ -177,7 +177,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_pause(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/pause",
             status_code=204,
         )
@@ -188,7 +188,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_wait(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/wait",
             status_code=200,
             json={"StatusCode": 0},
@@ -205,7 +205,7 @@ class ContainersTestCase(unittest.TestCase):
             {"Path": "deleted", "Kind": 2},
         ]
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/changes",
             json=payload,
         )
@@ -217,7 +217,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_diff_404(self, mock):
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/changes",
             json={
                 "cause": "Container not found.",
@@ -236,7 +236,7 @@ class ContainersTestCase(unittest.TestCase):
         tarball = b'Yet another weird tarball...'
         body = io.BytesIO(tarball)
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/export",
             body=body,
         )
@@ -262,7 +262,7 @@ class ContainersTestCase(unittest.TestCase):
         encoded_value = base64.urlsafe_b64encode(json.dumps(header_value).encode("utf8"))
 
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/archive"
             "?path=/etc/motd",
             body=body,
@@ -283,15 +283,15 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_commit(self, mock):
         post_adapter = mock.post(
-            tests.BASE_URL + "/libpod/commit"
-            "?author=redhat&changes=ADD+%2Fetc%2Fmod&comment=This+is+a+unittest"
+            tests.LIBPOD_URL + "/commit"
+            "?author=redhat&changes=ADD+%2fetc%2fmod&comment=This+is+a+unittest"
             "&container=87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd&format=docker"
             "&pause=True&repo=quay.local&tag=unittest",
             status_code=201,
             json={"ID": "d2459aad75354ddc9b5b23f863786e279637125af6ba4d4a83f881866b3c903f"},
         )
         get_adapter = mock.get(
-            tests.BASE_URL + "/libpod/images/"
+            tests.LIBPOD_URL + "/images/"
             "d2459aad75354ddc9b5b23f863786e279637125af6ba4d4a83f881866b3c903f/json",
             json={"Id": "d2459aad75354ddc9b5b23f863786e279637125af6ba4d4a83f881866b3c903f"},
         )
@@ -316,9 +316,9 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_put_archive(self, mock):
         adapter = mock.put(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/archive"
-            "?path=%2Fetc%2Fmotd",
+            "?path=%2fetc%2fmotd",
             status_code=200,
         )
         container = Container(attrs=FIRST_CONTAINER, client=self.client.api)
@@ -332,7 +332,7 @@ class ContainersTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_put_archive_404(self, mock):
         adapter = mock.put(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/archive"
             "?path=deadbeef",
             status_code=404,
@@ -370,7 +370,7 @@ class ContainersTestCase(unittest.TestCase):
             "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
         }
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/top",
             json=body,
         )

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -47,7 +47,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers"
+            tests.LIBPOD_URL + "/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -62,7 +62,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_404(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers"
+            tests.LIBPOD_URL + "/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json={
                 "cause": "Container not found.",
@@ -80,7 +80,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_empty(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers/json",
+            tests.LIBPOD_URL + "/containers/json",
             text="[]",
         )
         actual = self.client.containers.list()
@@ -89,7 +89,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers/json",
+            tests.LIBPOD_URL + "/containers/json",
             json=[FIRST_CONTAINER, SECOND_CONTAINER],
         )
         actual = self.client.containers.list()
@@ -105,7 +105,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_filtered(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers/json?"
+            tests.LIBPOD_URL + "/containers/json?"
             "all=True"
             "&filters=%7B"
             "%22before%22%3A"
@@ -133,7 +133,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_no_filters(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/containers/json",
+            tests.LIBPOD_URL + "/containers/json",
             json=[FIRST_CONTAINER, SECOND_CONTAINER],
         )
         actual = self.client.containers.list()
@@ -149,7 +149,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/containers/prune",
+            tests.LIBPOD_URL + "/containers/prune",
             json=[
                 {
                     "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -176,7 +176,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/containers/create",
+            tests.LIBPOD_URL + "/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -184,7 +184,7 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.get(
-            tests.BASE_URL + "/libpod/containers"
+            tests.LIBPOD_URL + "/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -195,7 +195,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_404(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/containers/create",
+            tests.LIBPOD_URL + "/containers/create",
             status_code=404,
             json={
                 "cause": "Image not found",
@@ -217,7 +217,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_run_detached(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/containers/create",
+            tests.LIBPOD_URL + "/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -225,12 +225,12 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start",
             status_code=204,
         )
         mock.get(
-            tests.BASE_URL + "/libpod/containers"
+            tests.LIBPOD_URL + "/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )
@@ -245,7 +245,7 @@ class ContainersManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_run(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/containers/create",
+            tests.LIBPOD_URL + "/containers/create",
             status_code=201,
             json={
                 "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -253,12 +253,12 @@ class ContainersManagerTestCase(unittest.TestCase):
             },
         )
         mock.post(
-            tests.BASE_URL + "/libpod/containers/"
+            tests.LIBPOD_URL + "/containers/"
             "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/start",
             status_code=204,
         )
         mock.get(
-            tests.BASE_URL + "/libpod/containers"
+            tests.LIBPOD_URL + "/containers"
             "/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/json",
             json=FIRST_CONTAINER,
         )

--- a/podman/tests/unit/test_events.py
+++ b/podman/tests/unit/test_events.py
@@ -44,7 +44,7 @@ class EventsManagerTestCase(unittest.TestCase):
             buffer.write(json.JSONEncoder().encode(item))
             buffer.write("\n")
 
-        adapter = mock.get(tests.BASE_URL + "/libpod/events", text=buffer.getvalue())
+        adapter = mock.get(tests.LIBPOD_URL + "/events", text=buffer.getvalue())
 
         manager = EventsManager(client=self.client.api)
         actual = manager.list(decode=True)

--- a/podman/tests/unit/test_image.py
+++ b/podman/tests/unit/test_image.py
@@ -49,7 +49,7 @@ class ImageTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_history(self, mock):
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/history",
             json=[
                 {
@@ -74,7 +74,7 @@ class ImageTestCase(unittest.TestCase):
         update["Containers"] = 0
 
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             [
                 {"json": FIRST_IMAGE},
@@ -98,7 +98,7 @@ class ImageTestCase(unittest.TestCase):
         body = io.BytesIO(tarball)
 
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/images/"
+            tests.LIBPOD_URL + "/images/"
             "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/get",
             body=body,
         )

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -38,7 +38,7 @@ SECOND_IMAGE = {
 }
 
 
-class TestClientImagesManager(unittest.TestCase):
+class ImagesManagerTestCase(unittest.TestCase):
     """Test ImagesManager area of concern.
 
     Note:
@@ -64,7 +64,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_list_empty(self, mock):
         """Unit test Images list()."""
         mock.get(
-            tests.BASE_URL + "/libpod/images/json",
+            tests.LIBPOD_URL + "/images/json",
             text="[]",
         )
 
@@ -75,7 +75,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_list_1(self, mock):
         """Unit test Images list()."""
         mock.get(
-            tests.BASE_URL + "/libpod/images/json",
+            tests.LIBPOD_URL + "/images/json",
             json=[FIRST_IMAGE],
         )
 
@@ -102,7 +102,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_list_2(self, mock):
         """Unit test Images list()."""
         mock.get(
-            tests.BASE_URL + "/libpod/images/json",
+            tests.LIBPOD_URL + "/images/json",
             json=[FIRST_IMAGE, SECOND_IMAGE],
         )
 
@@ -123,8 +123,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_list_filters(self, mock):
         """Unit test filters param for Images list()."""
         mock.get(
-            tests.BASE_URL + "/libpod/images/json"
-            "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
+            tests.LIBPOD_URL + "/images/json" "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
             json=[FIRST_IMAGE],
         )
 
@@ -137,7 +136,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_list_all(self, mock):
         """Unit test filters param for Images list()."""
         mock.get(
-            tests.BASE_URL + "/libpod/images/json?all=true",
+            tests.LIBPOD_URL + "/images/json?all=true",
             json=[FIRST_IMAGE],
         )
 
@@ -150,7 +149,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_prune(self, mock):
         """Unit test Images prune()."""
         mock.post(
-            tests.BASE_URL + "/libpod/images/prune",
+            tests.LIBPOD_URL + "/images/prune",
             json=[
                 {
                     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -174,8 +173,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_prune_filters(self, mock):
         """Unit test filters param for Images prune()."""
         mock.post(
-            tests.BASE_URL + "/libpod/images/prune"
-            "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
+            tests.LIBPOD_URL + "/images/prune" "?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
             json=[
                 {
                     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -207,7 +205,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_prune_failure(self, mock):
         """Unit test to report error carried in response body."""
         mock.post(
-            tests.BASE_URL + "/libpod/images/prune",
+            tests.LIBPOD_URL + "/images/prune",
             json=[
                 {
                     "Err": "Test prune failure in response body.",
@@ -222,7 +220,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/fedora%3Alatest/json",
+            tests.LIBPOD_URL + "/images/fedora%3Alatest/json",
             json=FIRST_IMAGE,
         )
 
@@ -233,7 +231,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_oserror(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/bad_image/json",
+            tests.LIBPOD_URL + "/images/bad_image/json",
             exc=OSError,
         )
 
@@ -241,13 +239,13 @@ class TestClientImagesManager(unittest.TestCase):
             _ = self.client.images.get("bad_image")
         self.assertEqual(
             str(e.exception),
-            tests.BASE_URL + "/libpod/images/bad_image/json (GET operation failed)",
+            tests.LIBPOD_URL + "/images/bad_image/json (GET operation failed)",
         )
 
     @requests_mock.Mocker()
     def test_get_404(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/bad_image/json",
+            tests.LIBPOD_URL + "/images/bad_image/json",
             status_code=404,
             json={
                 "cause": "Image not found",
@@ -262,7 +260,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_500(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/bad_image/json",
+            tests.LIBPOD_URL + "/images/bad_image/json",
             status_code=500,
             json={
                 "cause": "Server error",
@@ -277,7 +275,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove(self, mock):
         mock.delete(
-            tests.BASE_URL + "/libpod/images/fedora:latest",
+            tests.LIBPOD_URL + "/images/fedora:latest",
             json={
                 "Untagged": ["326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"],
                 "Deleted": [
@@ -308,11 +306,11 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_load(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/images/load",
+            tests.LIBPOD_URL + "/images/load",
             json={"Names": ["quay.io/fedora:latest"]},
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images/quay.io%2Ffedora%3Alatest/json",
+            tests.LIBPOD_URL + "/images/quay.io%2ffedora%3Alatest/json",
             json=FIRST_IMAGE,
         )
 
@@ -328,7 +326,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_search(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/search?term=fedora&noTrunc=true",
+            tests.LIBPOD_URL + "/images/search?term=fedora&noTrunc=true",
             json=[
                 {
                     "description": "mock term=fedora search",
@@ -348,7 +346,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_search_oserror(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/search?term=fedora&noTrunc=true",
+            tests.LIBPOD_URL + "/images/search?term=fedora&noTrunc=true",
             exc=OSError,
         )
 
@@ -358,7 +356,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_search_500(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/search?term=fedora&noTrunc=true",
+            tests.LIBPOD_URL + "/images/search?term=fedora&noTrunc=true",
             status_code=500,
             json={
                 "cause": "Server error",
@@ -373,7 +371,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_search_limit(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/search?term=fedora&noTrunc=true&limit=5",
+            tests.LIBPOD_URL + "/images/search?term=fedora&noTrunc=true&limit=5",
             json=[
                 {
                     "description": "mock term=fedora search",
@@ -393,7 +391,7 @@ class TestClientImagesManager(unittest.TestCase):
     @requests_mock.Mocker()
     def test_search_filters(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/search"
+            tests.LIBPOD_URL + "/images/search"
             "?filters=%7B%22stars%22%3A+%5B%225%22%5D%7D&noTrunc=True&term=fedora",
             json=[
                 {
@@ -413,7 +411,7 @@ class TestClientImagesManager(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_push(self, mock):
-        mock.post(tests.BASE_URL + "/libpod/images/quay.io%2Ffedora/push")
+        mock.post(tests.LIBPOD_URL + "/images/quay.io%2ffedora/push")
 
         report = self.client.images.push("quay.io/fedora", "latest")
 
@@ -426,7 +424,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_pull(self, mock):
         image_id = "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
         mock.post(
-            tests.BASE_URL + "/libpod/images/pull" "?reference=quay.io%2Ffedora%3Alatest",
+            tests.LIBPOD_URL + "/images/pull" "?reference=quay.io%2ffedora%3Alatest",
             json={
                 "error": "",
                 "id": image_id,
@@ -435,7 +433,7 @@ class TestClientImagesManager(unittest.TestCase):
             },
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/sha256%3A326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )
@@ -447,7 +445,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_pull_enhanced(self, mock):
         image_id = "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
         mock.post(
-            tests.BASE_URL + "/libpod/images/pull" "?reference=quay.io%2Ffedora%3Alatest",
+            tests.LIBPOD_URL + "/images/pull" "?reference=quay.io%2ffedora%3Alatest",
             json={
                 "error": "",
                 "id": image_id,
@@ -456,7 +454,7 @@ class TestClientImagesManager(unittest.TestCase):
             },
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/sha256%3A326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )
@@ -468,7 +466,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_pull_platform(self, mock):
         image_id = "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/images/pull?reference=quay.io%2Ffedora%3Alatest&OS=linux",
+            tests.LIBPOD_URL + "/images/pull?reference=quay.io%2ffedora%3Alatest&OS=linux",
             json={
                 "error": "",
                 "id": image_id,
@@ -477,7 +475,7 @@ class TestClientImagesManager(unittest.TestCase):
             },
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/sha256%3A326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )
@@ -490,7 +488,7 @@ class TestClientImagesManager(unittest.TestCase):
     def test_pull_2x(self, mock):
         image_id = "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
         mock.post(
-            tests.BASE_URL + "/libpod/images/pull" "?reference=quay.io%2Ffedora&allTags=True",
+            tests.LIBPOD_URL + "/images/pull" "?reference=quay.io%2ffedora&allTags=True",
             json={
                 "error": "",
                 "id": image_id,
@@ -502,12 +500,12 @@ class TestClientImagesManager(unittest.TestCase):
             },
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/sha256%3A326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )
         mock.get(
-            tests.BASE_URL + "/libpod/images"
+            tests.LIBPOD_URL + "/images"
             "/c4b16966ecd94ffa910eab4e630e24f259bf34a87e924cd4b1434f267b0e354e/json",
             json=SECOND_IMAGE,
         )

--- a/podman/tests/unit/test_network.py
+++ b/podman/tests/unit/test_network.py
@@ -84,7 +84,7 @@ class NetworkTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove(self, mock):
         adapter = mock.delete(
-            "http+unix://localhost:9999/v1.40/networks/podman",
+            tests.COMPATIBLE_URL + "/networks/podman?force=True",
             status_code=204,
             json={"Name": "podman", "Err": None},
         )
@@ -96,9 +96,7 @@ class NetworkTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_connect(self, mock):
-        adapter = mock.post(
-            "http+unix://localhost:9999/v1.40/networks/podman/connect",
-        )
+        adapter = mock.post(tests.COMPATIBLE_URL + "/networks/podman/connect")
         net = Network(attrs=FIRST_NETWORK, client=self.client.api)
 
         net.connect(
@@ -122,9 +120,7 @@ class NetworkTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_disconnect(self, mock):
-        adapter = mock.post(
-            "http+unix://localhost:9999/v1.40/networks/podman/disconnect",
-        )
+        adapter = mock.post(tests.COMPATIBLE_URL + "/networks/podman/disconnect")
         net = Network(attrs=FIRST_NETWORK, client=self.client.api)
 
         net.disconnect("podman_ctnr", force=True)

--- a/podman/tests/unit/test_networksmanager.py
+++ b/podman/tests/unit/test_networksmanager.py
@@ -125,7 +125,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v1.40/networks/podman",
+            tests.COMPATIBLE_URL + "/networks/podman",
             json=FIRST_NETWORK,
         )
 
@@ -138,7 +138,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_libpod(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/networks/podman/json",
+            tests.LIBPOD_URL + "/networks/podman/json",
             json=FIRST_NETWORK_LIBPOD,
         )
 
@@ -149,7 +149,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list(self, mock):
         mock.get(
-            "http+unix://localhost:9999/v1.40/networks",
+            tests.COMPATIBLE_URL + "/networks",
             json=[FIRST_NETWORK, SECOND_NETWORK],
         )
 
@@ -171,7 +171,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_libpod(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/networks/json",
+            tests.LIBPOD_URL + "/networks/json",
             json=FIRST_NETWORK_LIBPOD + SECOND_NETWORK_LIBPOD,
         )
 
@@ -193,13 +193,13 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/networks/create?name=podman",
+            tests.LIBPOD_URL + "/networks/create?name=podman",
             json={
                 "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
             },
         )
         mock.get(
-            "http+unix://localhost:9999/v1.40/networks/podman",
+            tests.COMPATIBLE_URL + "/networks/podman",
             json=FIRST_NETWORK,
         )
 
@@ -228,13 +228,13 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_defaults(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/networks/create?name=podman",
+            tests.LIBPOD_URL + "/networks/create?name=podman",
             json={
                 "Filename": "/home/developer/.config/cni/net.d/podman.conflist",
             },
         )
         mock.get(
-            "http+unix://localhost:9999/v1.40/networks/podman",
+            tests.COMPATIBLE_URL + "/networks/podman",
             json=FIRST_NETWORK,
         )
 
@@ -246,7 +246,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         mock.post(
-            "http+unix://localhost:9999/v1.40/networks/prune",
+            tests.COMPATIBLE_URL + "/networks/prune",
             json={"NetworksDeleted": ["podman", "database"]},
         )
 
@@ -256,7 +256,7 @@ class NetworksManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune_libpod(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/networks/prune",
+            tests.LIBPOD_URL + "/networks/prune",
             json=[
                 {"Name": "podman", "Error": None},
                 {"Name": "database", "Error": None},

--- a/podman/tests/unit/test_pod.py
+++ b/podman/tests/unit/test_pod.py
@@ -36,7 +36,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_kill(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/kill",
             json={
                 "Errs": [],
@@ -51,7 +51,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_kill_404(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/kill",
             status_code=404,
             json={
@@ -69,7 +69,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_pause(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/pause",
             json={
                 "Errs": [],
@@ -84,7 +84,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_pause_404(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/pause",
             status_code=404,
             json={
@@ -102,7 +102,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove(self, mock):
         adapter = mock.delete(
-            tests.BASE_URL + "/libpod/pods/"
+            tests.LIBPOD_URL + "/pods/"
             "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8?force=True",
             json={
                 "Errs": [],
@@ -118,7 +118,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_restart(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/restart",
             json={
                 "Errs": [],
@@ -133,7 +133,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_start(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/start",
             json={
                 "Errs": [],
@@ -148,7 +148,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_stop(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/stop?t=70.0",
             json={
                 "Errs": [],
@@ -180,7 +180,7 @@ class PodTestCase(unittest.TestCase):
             "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
         }
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/top"
             "?ps_args=aux&stream=False",
             json=body,
@@ -194,7 +194,7 @@ class PodTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_unpause(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/unpause",
             json={
                 "Errs": [],

--- a/podman/tests/unit/test_podmanclient.py
+++ b/podman/tests/unit/test_podmanclient.py
@@ -27,11 +27,25 @@ class TestPodmanClient(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get(tests.BASE_URL + "/libpod/info", json=body)
+        adapter = mock.get(tests.LIBPOD_URL + "/info", json=body)
 
-        with PodmanClient(base_url="http+unix://localhost:9999") as client:
+        with PodmanClient(base_url=tests.BASE_SOCK) as client:
             actual = client.info()
         self.assertDictEqual(actual, body)
+        self.assertIn("User-Agent", mock.last_request.headers)
+        self.assertIn(
+            "PodmanPy/", mock.last_request.headers["User-Agent"], mock.last_request.headers
+        )
+
+    def test_swarm(self):
+        with PodmanClient(base_url=tests.BASE_SOCK) as client:
+            with self.assertRaises(NotImplementedError):
+                # concrete property
+                _ = client.swarm
+
+            with self.assertRaises(NotImplementedError):
+                # aliased property
+                _ = client.nodes
 
 
 if __name__ == '__main__':

--- a/podman/tests/unit/test_podsmanager.py
+++ b/podman/tests/unit/test_podsmanager.py
@@ -35,12 +35,12 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods/create",
+            tests.LIBPOD_URL + "/pods/create",
             json={"Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"},
             status_code=201,
         )
         mock.get(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
             json=FIRST_POD,
         )
@@ -54,7 +54,7 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
             json=FIRST_POD,
         )
@@ -69,7 +69,7 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get404(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/pods"
+            tests.LIBPOD_URL + "/pods"
             "/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/json",
             status_code=404,
             json={
@@ -86,7 +86,7 @@ class PodsManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_list(self, mock):
-        mock.get(tests.BASE_URL + "/libpod/pods/json", json=[FIRST_POD, SECOND_POD])
+        mock.get(tests.LIBPOD_URL + "/pods/json", json=[FIRST_POD, SECOND_POD])
 
         actual = self.client.pods.list()
 
@@ -100,7 +100,7 @@ class PodsManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/pods/prune",
+            tests.LIBPOD_URL + "/pods/prune",
             json=[
                 {
                     "Err": None,
@@ -144,7 +144,7 @@ class PodsManagerTestCase(unittest.TestCase):
             "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
         }
         mock.get(
-            tests.BASE_URL + "/libpod/pods/stats"
+            tests.LIBPOD_URL + "/pods/stats"
             "?namesOrIDs=c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
             json=body,
         )

--- a/podman/tests/unit/test_registrydata.py
+++ b/podman/tests/unit/test_registrydata.py
@@ -46,7 +46,7 @@ class RegistryDataTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_init(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/images/"
+            tests.LIBPOD_URL + "/images/"
             "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab/json",
             json=FIRST_IMAGE,
         )

--- a/podman/tests/unit/test_system.py
+++ b/podman/tests/unit/test_system.py
@@ -35,7 +35,7 @@ class SystemTestCase(unittest.TestCase):
         }
 
         mock.get(
-            tests.BASE_URL + "/libpod/system/df",
+            tests.LIBPOD_URL + "/system/df",
             json=body,
         )
 
@@ -50,14 +50,14 @@ class SystemTestCase(unittest.TestCase):
                 "os": "linux",
             }
         }
-        mock.get(tests.BASE_URL + "/libpod/info", json=body)
+        mock.get(tests.LIBPOD_URL + "/info", json=body)
 
         actual = self.client.info()
         self.assertDictEqual(actual, body)
 
     @requests_mock.Mocker()
     def test_ping(self, mock):
-        mock.head(tests.BASE_URL + "/libpod/_ping")
+        mock.head(tests.LIBPOD_URL + "/_ping")
         self.assertTrue(self.client.ping())
 
     @requests_mock.Mocker()
@@ -68,7 +68,7 @@ class SystemTestCase(unittest.TestCase):
             "Arch": "amd64",
             "Os": "linux",
         }
-        mock.get(tests.BASE_URL + "/libpod/version", json=body)
+        mock.get(tests.LIBPOD_URL + "/version", json=body)
         self.assertDictEqual(self.client.version(), body)
 
 

--- a/podman/tests/unit/test_volume.py
+++ b/podman/tests/unit/test_volume.py
@@ -32,7 +32,7 @@ class VolumeTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_remove(self, mock):
-        adapter = mock.delete(tests.BASE_URL + "/libpod/volumes/dbase?force=True", status_code=204)
+        adapter = mock.delete(tests.LIBPOD_URL + "/volumes/dbase?force=True", status_code=204)
         vol_manager = VolumesManager(self.client.api)
         volume = vol_manager.prepare_model(attrs=FIRST_VOLUME)
 

--- a/podman/tests/unit/test_volumesmanager.py
+++ b/podman/tests/unit/test_volumesmanager.py
@@ -51,7 +51,7 @@ class VolumesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create(self, mock):
         adapter = mock.post(
-            tests.BASE_URL + "/libpod/volumes/create",
+            tests.LIBPOD_URL + "/volumes/create",
             json=FIRST_VOLUME,
             status_code=requests.codes.created,
         )
@@ -84,7 +84,7 @@ class VolumesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
-            tests.BASE_URL + "/libpod/volumes/dbase/json",
+            tests.LIBPOD_URL + "/volumes/dbase/json",
             json=FIRST_VOLUME,
         )
 
@@ -96,7 +96,7 @@ class VolumesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_404(self, mock):
         adapter = mock.get(
-            tests.BASE_URL + "/libpod/volumes/dbase/json",
+            tests.LIBPOD_URL + "/volumes/dbase/json",
             text="Not Found",
             status_code=404,
         )
@@ -107,7 +107,7 @@ class VolumesManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_list(self, mock):
-        mock.get(tests.BASE_URL + "/libpod/volumes/json", json=[FIRST_VOLUME, SECOND_VOLUME])
+        mock.get(tests.LIBPOD_URL + "/volumes/json", json=[FIRST_VOLUME, SECOND_VOLUME])
 
         actual = self.client.volumes.list(filters={"driver": "local"})
         self.assertEqual(len(actual), 2)
@@ -120,7 +120,7 @@ class VolumesManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_list_404(self, mock):
-        mock.get(tests.BASE_URL + "/libpod/volumes/json", text="Not Found", status_code=404)
+        mock.get(tests.LIBPOD_URL + "/volumes/json", text="Not Found", status_code=404)
 
         actual = self.client.volumes.list()
         self.assertIsInstance(actual, list)
@@ -129,7 +129,7 @@ class VolumesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_prune(self, mock):
         mock.post(
-            tests.BASE_URL + "/libpod/volumes/prune",
+            tests.LIBPOD_URL + "/volumes/prune",
             json=[
                 {"Id": "dbase", "Size": 1024},
                 {"Id": "source", "Size": 1024},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.24
 toml>=0.10.2
 urllib3~=1.26.4
+pyxdg~=0.27


### PR DESCRIPTION
* Add support for ssh:// and tcp: transports
* Add minimal tests for each transport
* Update tests to reflect transport changes
* Cleaned up timeout handling, lower APIs do not test for None vs.
  non-existing keyword argument
* Introduced cached_property decorator, mostly to cache creating
  managers.
* Improved docstrings
* Improved formatting URLs for future SSL verification and
  authenication.
* Bump to __version__ 3.1.2.1 tracking to Podman
* Added pyxdg dependency

Signed-off-by: Jhon Honce <jhonce@redhat.com>