### PR TITLE
Bump version for packaging changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ HEAD ?= HEAD
 
 export PODMAN_VERSION ?= "3.2.0"
 
-.PHONY: podman-py
-podman-py:
+.PHONY: podman
+podman:
 	rm dist/* || :
 	python -m pip install --user -r requirements.txt
 	PODMAN_VERSION=$(PODMAN_VERSION) \
@@ -38,15 +38,17 @@ integration:
 	coverage run -m unittest discover -s podman/tests/integration
 	coverage report -m --skip-covered --fail-under=80 --omit=./podman/tests/* --omit=.tox/* --omit=/usr/lib/*
 
-.PHONY: upload
-upload:
-	twine upload --verbose -r testpypi dist/*whl dist/*zip
-	# pip install -i https://test.pypi.org/simple/ podman-py
+.PHONY: test-release
+test-release: SOURCE = $(shell find dist -regex '.*/podman-[0-9][0-9\.]*.tar.gz' -print)
+test-release:
+	twine upload --verbose -r testpypi dist/*whl $(SOURCE)
+	# pip install -i https://test.pypi.org/simple/ podman
 
 .PHONY: release
+release: SOURCE = $(shell find dist -regex '.*/podman-[0-9][0-9\.]*.tar.gz' -print)
 release:
-	twine upload --verbose dist/*whl dist/*zip
-	# pip install podman-py
+	twine upload --verbose dist/*whl $(SOURCE)
+	# pip install podman
 
 .PHONY: docs
 docs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # podman-py
 [![Build Status](https://api.cirrus-ci.com/github/containers/podman-py.svg)](https://cirrus-ci.com/github/containers/podman-py/main)
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/23171)
 
 This python package is a library of bindings to use the RESTful API of [Podman](https://github.com/containers/podman).
 It is currently under development and contributors are welcome!

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = u'2021, Red Hat Inc'
 author = u'Red Hat Inc'
 
 # The full version, including alpha/beta/rc tags
-version = '3.1.2.4'
+version = '3.1.2.5'
 release = version
 
 add_module_names = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,13 @@
-PodmanPy: Python scripting for Podman services
+Podman: Python scripting for Podman services
 ==============================================
-.. image:: https://img.shields.io/pypi/l/podman-py.svg
-    :target: https://pypi.org/project/podman-py/
+.. image:: https://img.shields.io/pypi/l/podman.svg
+    :target: https://pypi.org/project/podman/
 
-.. image:: https://img.shields.io/pypi/wheel/podman-py.svg
-    :target: https://pypi.org/project/podman-py/
+.. image:: https://img.shields.io/pypi/wheel/podman.svg
+    :target: https://pypi.org/project/podman/
 
-.. image:: https://img.shields.io/pypi/pyversions/podman-py.svg
-    :target: https://pypi.org/project/podman-py/
+.. image:: https://img.shields.io/pypi/pyversions/podman.svg
+    :target: https://pypi.org/project/podman/
 
 PodmanPy is a Python3 module that allows you to write Python scripts that access resources
 maintained by a Podman service. It leverages the Podman service RESTful API.

--- a/podman/__init__.py
+++ b/podman/__init__.py
@@ -8,7 +8,7 @@ except ImportError:
             raise NotImplementedError("ApiConnection deprecated, please use PodmanClient().")
 
 
-from podman.api.version import __version__
+from podman.version import __version__
 from podman.client import PodmanClient, from_env
 
 # isort: unique-list

--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -14,7 +14,7 @@ from podman.api.parse_utils import (
 )
 from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_containerignore
 
-from . import version
+from .. import version
 
 DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024
 

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -8,7 +8,7 @@ from requests.adapters import HTTPAdapter
 
 from podman import api
 from podman.api.ssh import SSHAdapter
-from podman.api.version import __version__
+from podman.version import __version__
 from podman.api.uds import UDSAdapter
 from podman.errors import APIError, NotFound
 from podman.tlsconfig import TLSConfig

--- a/podman/version.py
+++ b/podman/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "3.1.2.4"
+__version__ = "3.1.2.5"
 __compatible_version__ = "1.40"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,7 @@ profile = "black"
 line_length = 100
 [build-system]
 requires = [
-    "requests>=2.24",
-    "toml>=0.10.2",
-    "urllib3>=1.24.2",
-    "pyxdg>=0.26",
-    "setuptools>=42",
+    "setuptools>=46.4",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = podman-py
+name = podman
 version = attr: podman.__version__
 author = Brent Baude, Jhon Honce
 author_email = jhonce@redhat.com


### PR DESCRIPTION
* Fixme dependencies in pyproject.toml
* Move version.py to prevent packaging issues
* Publish non-arch source to PyPi
* Bump version to 3.1.2.5

Signed-off-by: Jhon Honce <jhonce@redhat.com>