### PR TITLE
Followup to master -> main conversion

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 
 env:
-    DEST_BRANCH: "master"
+    DEST_BRANCH: "main"
     GOPATH: "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
     GOCACHE: "${GOPATH}/cache"

--- a/contrib/cirrus/latest_podman.sh
+++ b/contrib/cirrus/latest_podman.sh
@@ -15,7 +15,7 @@ cd "$GOPATH/src/github.com/containers/"
 
 systemctl stop podman.socket ||:
 dnf erase podman -y
-git clone --branch master https://github.com/containers/podman.git
+git clone https://github.com/containers/podman.git
 
 cd podman
 make binaries


### PR DESCRIPTION
Fix the intended destination branch referenced in Cirrus-CI
configuration.

Also update the `latest_podman.sh` script so it won't be sensitive to
`containers/podman` converting master -> main at some future date.

Signed-off-by: Chris Evich <cevich@redhat.com>