### PR TITLE
Add inspect capability to this container

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -214,7 +214,7 @@ class Container(PodmanResource):
         stat = api.decode_header(stat)
         return response.iter_content(chunk_size=chunk_size), stat
 
-    def inspect(self) -> None:
+    def inspect(self) -> Dict:
         """Inspect a container.
 
         Raises:

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -214,6 +214,16 @@ class Container(PodmanResource):
         stat = api.decode_header(stat)
         return response.iter_content(chunk_size=chunk_size), stat
 
+    def inspect(self) -> None:
+        """Inspect a container.
+
+        Raises:
+            APIError: when service reports an error
+        """
+        response = self.client.post(f"/containers/{self.id}/json")
+        response.raise_for_status()
+        return response.json()
+
     def kill(self, signal: Union[str, int, None] = None) -> None:
         """Send signal to container.
 


### PR DESCRIPTION
While developing against this API, I found the need to inspect a
container and gain an insight into its internals. It appeared that
inspect had not been implemented in podman-py, so I added it,
duplicating some code from the `container.kill()` function.

Signed-off-by: Eamonn Nugent <4699217+space55@users.noreply.github.com>