### PR TITLE
inspect should call a get not a post

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -220,7 +220,7 @@ class Container(PodmanResource):
         Raises:
             APIError: when service reports an error
         """
-        response = self.client.post(f"/containers/{self.id}/json")
+        response = self.client.get(f"/containers/{self.id}/json")
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
We can't post on that endpoint, it has to be a get.

```
Traceback (most recent call last):
  File "clone_container.py", line 87, in <module>
    main()
  File "clone_container.py", line 80, in main
    inspect = container.inspect()
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/podman/domain/containers.py", line 225, in inspect
    response.raise_for_status()
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/podman/api/client.py", line 57, in raise_for_status
    body = self.json()
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/requests/models.py", line 900, in json
    return complexjson.loads(self.text, **kwargs)
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/simplejson/__init__.py", line 525, in loads
    return _default_decoder.decode(s)
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/home/dvd/git/downstream/randoms/bin/.venv/lib/python3.7/site-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```