### PR TITLE
Update tests re: changes in containers.logs()

### DIFF
--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -99,7 +99,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.assertIsInstance(logs_iter, Iterator)
 
             logs = list(logs_iter)
-            self.assertIn(random_string.encode("utf-8"), logs)
+            self.assertIn((random_string + "\n").encode("utf-8"), logs)
 
         with self.subTest("Delete Container"):
             container.remove()


### PR DESCRIPTION
In Podman 4.0, logs now return trailing newlines.

Needed to unblock PR queue

Signed-off-by: Jhon Honce <jhonce@redhat.com>