### PR TITLE
Assert Python version >= 3.6

### DIFF
--- a/podman/__init__.py
+++ b/podman/__init__.py
@@ -1,4 +1,8 @@
 """Podman client module."""
+import sys
+
+assert sys.version_info >= (3, 6), "Python 3.6 or greater is required."
+
 try:
     from podman.api_connection import ApiConnection
 except ImportError:


### PR DESCRIPTION
Attempt to print meaningful error message if an older version Python
is used.

Signed-off-by: Jhon Honce <jhonce@redhat.com>