### PR TITLE
Allow having image with ':'

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -33,8 +33,6 @@ class Container(PodmanResource):
         """podman.domain.images.Image: Returns Image object used to create Container."""
         if "Image" in self.attrs:
             image_id = self.attrs["Image"]
-            if ":" in image_id:
-                image_id = image_id.split(":")[1]
 
             return ImagesManager(client=self.client).get(image_id)
         return Image()


### PR DESCRIPTION
Signed-off-by: Szymon Jankowiak <szymon.jankowiak@motorolasolutions.com>

I've simply removed the split. The only usage of this split which comes to my mind would be if someone wanted to get a image by digest ... but even then it wouldn't work : 

Testing environment : 
```
[root@host ~]# podman ps -a
CONTAINER ID  IMAGE                    COMMAND     CREATED        STATUS      PORTS       NAMES
6c274c264cb5  registry:443/a/b/c:test  /bin/bash   3 minutes ago  Created                 the_test

[root@host ~]# cat test.py
#!/usr/bin/python3

import podman
client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock', timeout=300)
container = client.containers.list(all=True)[0]
print(f'Container Image from attrs["Image"] : {container.attrs["Image"]}')
print(f'Container Image from .image : {container.image}')
```

Before change : 

```
[root@host ~]# ./test.py
Container Image from attrs["Image"] : registry:443/a/b/c:test
Traceback (most recent call last):
  File "./test.py", line 7, in <module>
    print(f'Container Image from .image : {container.image}')
  File "/usr/lib/python3.6/site-packages/podman/domain/containers.py", line 39, in image
    return ImagesManager(client=self.client).get(image_id)
  File "/usr/lib/python3.6/site-packages/podman/domain/images_manager.py", line 74, in get
    response.raise_for_status(not_found=ImageNotFound)
  File "/usr/lib/python3.6/site-packages/podman/api/client.py", line 64, in raise_for_status
    raise not_found(cause, response=self._response, explanation=message)
podman.errors.exceptions.ImageNotFound: 404 Client Error: Not Found (failed to find image 443/a/b/c: 443/a/b/c: image not known)

[root] tox -e coverage

...

Ran 277 tests in 35.791s

FAILED (SKIP=3, errors=5, failures=3)
```

After change : 

```
[root@host ~]# ./test.py
Container Image from attrs["Image"] : registry:443/a/b/c:test
Container Image from .image : <Image: 'registry:443/a/b/c:test'>

[root] tox -e coverage
...
Ran 277 tests in 46.947s

FAILED (SKIP=3, errors=5, failures=3)
```

Proof that even if it was done by digest it wouldn't work as intended : 

```
[root@host~]# podman inspect registry:443/a/b/c:test --format '{{.Digest}}'
sha256:999725d1d88fe8891ca7ec4b8b02bad7f7026f9bfebdebfbf9e7b762dbf42c4e
Python 3.6.8 (default, Mar 18 2021, 08:58:41)
[GCC 8.4.1 20200928 (Red Hat 8.4.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from podman.api.client import APIClient
>>> import podman
>>> from podman.domain.images_manager import ImagesManager
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock', timeout=300)
>>> container = client.containers.list(all=True)[0]
>>> ImagesManager(client=container.client).get('999725d1d88fe8891ca7ec4b8b02bad7f7026f9bfebdebfbf9e7b762dbf42c4e')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/podman/domain/images_manager.py", line 74, in get
    response.raise_for_status(not_found=ImageNotFound)
  File "/usr/lib/python3.6/site-packages/podman/api/client.py", line 64, in raise_for_status
    raise not_found(cause, response=self._response, explanation=message)
podman.errors.exceptions.ImageNotFound: 404 Client Error: Not Found (failed to find image 999725d1d88fe8891ca7ec4b8b02bad7f7026f9bfebdebfbf9e7b762dbf42c4e: 999725d1d88fe8891ca7ec4b8b02bad7f7026f9bfebdebfbf9e7b762dbf42c4e: image not known)
```

Maybe it was designed for different case ? If so, please let me know.
