### PR TITLE
Allow passing labels to volumes

### DIFF
--- a/podman/domain/volumes.py
+++ b/podman/domain/volumes.py
@@ -60,7 +60,7 @@ class VolumesManager(Manager):
         """
         data = {
             "Driver": kwargs.get("driver"),
-            "Labels": kwargs.get("labels"),
+            "Label": kwargs.get("labels"),
             "Name": name,
             "Options": kwargs.get("driver_opts"),
         }

--- a/podman/tests/unit/test_volumesmanager.py
+++ b/podman/tests/unit/test_volumesmanager.py
@@ -68,7 +68,7 @@ class VolumesManagerTestCase(unittest.TestCase):
             adapter.last_request.json(),
             {
                 "Name": "dbase",
-                "Labels": {
+                "Label": {
                     "BackupRequired": True,
                 },
             },


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

Before changes : 

```
>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock', timeout=300)
>>> v = client.volumes.create('test', labels={'test_label': 'test_value'})
>>> v.attrs.get('Labels')
{}
>>>

[root@host~]# podman inspect test
[
    {
        "Name": "test",
        "Driver": "local",
        "Mountpoint": "/var/lib/containers/storage/volumes/test/_data",
        "CreatedAt": "2021-10-21T10:18:06.845889973Z",
        "Labels": {},
        "Scope": "local",
        "Options": {}
    }
]


Ran 277 tests in 34.861s

FAILED (SKIP=3, errors=5, failures=3)
```

After changes : 

```
>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock', timeout=300)
>>> v = client.volumes.create('test', labels={'test_label': 'test_value'})
>>> v.attrs.get('Labels')
{'test_label': 'test_value'}
>>>

[root@host~]# podman inspect test
[
    {
        "Name": "test",
        "Driver": "local",
        "Mountpoint": "/var/lib/containers/storage/volumes/test/_data",
        "CreatedAt": "2021-10-21T09:27:52.934957768Z",
        "Labels": {
            "test_label": "test_value"
        },
        "Scope": "local",
        "Options": {}
    }
]


# tox -e coverage

...

Ran 277 tests in 35.419s

FAILED (SKIP=3, errors=5, failures=3)
```

Tested on: 
```
[root@host~]# uname -a
Linux host.example.com 4.18.0-305.17.1.el8_4.x86_64 #1 SMP Mon Aug 30 07:26:31 EDT 2021 x86_64 x86_64 x86_64 GNU/Linux
[root@host~]# podman --version
podman version 3.2.3
```

I had to modify the test case since it failed on assertion (Labels vs Label), but I'm wondering how this test even passed when it allegedly compared labels from create volume (https://github.com/containers/podman-py/blob/main/podman/tests/unit/test_volumesmanager.py#L77-L82).