### PR TITLE
Bugfix/extra hosts

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -302,7 +302,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             "expose": dict(),
             "groups": pop("group_add"),
             "healthconfig": pop("healthcheck"),
-            "hostadd": pop("extra_hosts"),
+            "hostadd": list(),
             "hostname": pop("hostname"),
             "httpproxy": pop("use_config_proxy"),
             "idmappings": pop("idmappings"),  # TODO document, podman only
@@ -366,6 +366,9 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
         for item in args.pop("exposed_ports", list()):
             port, protocol = item.split("/")
             params["expose"][int(port)] = protocol
+
+        for ip, hostname in args.pop("extra_hosts", dict()).items():
+            params["hostadd"].append(f"{ip}:{hostname}")
 
         if "log_config" in args:
             params["log_configuration"]["driver"] = args["log_config"].get("Type")

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -367,8 +367,8 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             port, protocol = item.split("/")
             params["expose"][int(port)] = protocol
 
-        for ip, hostname in args.pop("extra_hosts", dict()).items():
-            params["hostadd"].append(f"{ip}:{hostname}")
+        for hostname, ip in args.pop("extra_hosts", dict()).items():
+            params["hostadd"].append(f"{hostname}:{ip}")
 
         if "log_config" in args:
             params["log_configuration"]["driver"] = args["log_config"].get("Type")

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -1,0 +1,48 @@
+import unittest
+
+import podman.tests.integration.base as base
+from podman import PodmanClient
+
+
+# @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
+
+
+class ContainersIntegrationTest(base.IntegrationTest):
+    """Containers Integration tests."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.client = PodmanClient(base_url=self.socket_uri)
+        self.addCleanup(self.client.close)
+
+        self.alpine_image = self.client.images.pull("quay.io/libpod/alpine", tag="latest")
+        self.containers = []
+
+    def tearUp(self):
+        for container in self.containers:
+            container.remove(force=True)
+
+    def test_container_extra_hosts(self):
+        """Test Container Extra hosts"""
+        extra_hosts = {"host1 host3": "127.0.0.2", "host2": "127.0.0.3"}
+
+        with self.subTest("Check extra hosts in container object"):
+            proper_container = self.client.containers.create(
+                self.alpine_image, command=["cat", "/etc/hosts"], extra_hosts=extra_hosts
+            )
+            self.containers.append(proper_container)
+            formatted_hosts = [f"{hosts}:{ip}" for hosts, ip in extra_hosts.items()]
+            self.assertEqual(proper_container.attrs.get('HostConfig', dict()).get('ExtraHosts', list()), formatted_hosts)
+
+        with self.subTest("Check extra hosts in running container"):
+            proper_container.start()
+            proper_container.wait()
+            logs = b"\n".join(proper_container.logs()).decode()
+            formatted_hosts = [f"{ip} {hosts}" for hosts, ip in extra_hosts.items()]
+            for hosts_entry in formatted_hosts:
+                self.assertIn(hosts_entry, logs)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It was possible to pass extra_hosts earlier on but it was on user to know what is the format (["{hostname}:{ip}"], ...) and the documentation for podman-py was wrong. To make things more consistent with docker-py (https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config - because why not) I've added code to make it docker-py compliant and documentation (https://github.com/containers/podman-py/blob/main/podman/domain/containers_create.py#L70-L71) compliant, while keeping interface as easy as possible (dict over list with special formatted strings)

```
Before : 

>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> c = client.containers.create(name='test', image='test:latest', extra_hosts={"host1 host3": "127.0.0.2", "host2": "127.0.0.3"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/podman/domain/containers_create.py", line 224, in create
    response.raise_for_status(not_found=ImageNotFound)
  File "/usr/lib/python3.6/site-packages/podman/api/client.py", line 65, in raise_for_status
    raise APIError(cause, response=self._response, explanation=message)
podman.errors.exceptions.APIError: 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal object into Go struct field SpecGenerator.hostadd of type []string)

tox -e coverage :

Ran 277 tests in 39.548s

FAILED (SKIP=3, errors=5, failures=3)



After :

>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> c = client.containers.create(name='test', image='test:latest', extra_hosts={"host1 host3": "127.0.0.2", "host2": "127.0.0.3"})
>>> c.attrs['HostConfig']['ExtraHosts']
['host1 host3:127.0.0.2', 'host2:127.0.0.3']

...

[root@host ~]# podman exec test cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
127.0.0.2 host1 host3
127.0.0.3 host2

tox -e coverage :

Ran 277 tests in 35.199s

FAILED (SKIP=3, errors=5, failures=3)
```