### PR TITLE
Cleanup after two tests

### DIFF
--- a/podman/tests/integration/test_manifests.py
+++ b/podman/tests/integration/test_manifests.py
@@ -17,8 +17,12 @@ class ManifestsIntegrationTest(base.IntegrationTest):
         self.addCleanup(self.client.close)
 
         self.alpine_image = self.client.images.pull("quay.io/libpod/alpine", tag="latest")
+        self.invalid_manifest_name = "InvalidManifestName"
 
     def tearDown(self) -> None:
+        if self.client.images.exists(self.invalid_manifest_name):
+            self.client.images.remove(self.invalid_manifest_name, force=True)
+
         self.client.images.remove(self.alpine_image, force=True)
         with suppress(ImageNotFound):
             self.client.images.remove("quay.io/unittest/alpine:latest", force=True)
@@ -62,13 +66,8 @@ class ManifestsIntegrationTest(base.IntegrationTest):
 
     def test_create_409(self):
         """Test that invalid Image names are caught and not corrupt storage."""
-        manifest_name = "InvalidManifestName"
-        try:
-            with self.assertRaises(APIError):
-                self.client.manifests.create([manifest_name])
-        finally:
-            if self.client.images.exists(manifest_name):
-                self.client.images.remove(manifest_name, force=True)
+        with self.assertRaises(APIError):
+            self.client.manifests.create([self.invalid_manifest_name])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

Running coverage tests bricks environment which is run on. What is more, if you run tests twice it fails in `setUp()` method rather than inside of test.

I could have added removal of pods in `tearDown()` but then I'd have to keep a list of pod names in `self.pod_names = []` because later on there may be more tests (but I was unsure how many times tearDown is called when there are multiple tests, if it is only once then it may not work properly, because existing pod may be a problem for different test). I couldn't decide which one is better so for now I've added it in finally.

Prior to running tests : 
```
[user@host]$ podman images
REPOSITORY                                                   TAG       IMAGE ID      CREATED       SIZE
[user@host podman-py]$ podman ps -a
CONTAINER ID  IMAGE   COMMAND  CREATED  STATUS  PORTS   NAMES
[user@host podman-py]$ podman pod ls
POD ID  NAME    STATUS  CREATED  INFRA ID  # OF CONTAINERS
```

Before changes : 
```
[user@host podman-py]$ tox -e coverage
...
Ran 277 tests in 50.724s

FAILED (SKIP=3, errors=4, failures=4)
...
[user@host podman-py]$ podman images
Error: error parsing repository tag "InvalidManifestName":: repository name must be lowercase
[user@host podman-py]$ podman ps -a
CONTAINER ID  IMAGE                                         COMMAND  CREATED         STATUS             PORTS   NAMES
47fe736e106c  registry.access.redhat.com/ubi8/pause:latest           27 seconds ago  Up 27 seconds ago          edd2eb4232f7-infra
[user@host podman-py]$ podman pod ls
POD ID        NAME                                          STATUS   CREATED         INFRA ID      # OF CONTAINERS
edd2eb4232f7  pod_2e3c6f7cb57a9e074f015958c8180b6ff0d52eca  Running  29 seconds ago  47fe736e106c  1
[user@host podman-py]$

# existing pod is actually making 2nd run of tests to fail with message (2 occurrences): 
# podman.errors.exceptions.APIError: 500 Server Error: Internal Server Error (container 3d23198b376006fc1a33eaf6572447df79b04c40bc5217f89e32fe2f6496c1d0 is the infra container of pod 911b9d3fa8168f58bfe987d34c0d945437ceaafaa7fdeff5e8d15b120727d325 and cannot be removed without removing the pod)
# all of this because earlier test fails run of this test fails due to podman.errors.exceptions.APIError: 500 Server Error: Internal Server Error (can not pause pods containing rootless containers with cgroup V1: this container does not have a cgroup)
```
After changes :
```
[user@host podman-py]$ tox -e coverage
...
Ran 277 tests in 41.012s

FAILED (SKIP=3, errors=3, failures=4)
...

[user@host podman-py]$ podman images
REPOSITORY                                                   TAG       IMAGE ID      CREATED       SIZE
quay.io/libpod/alpine                                        latest    961769676411  2 years ago   5.85 MB
quay.io/libpod/alpine_labels                                 latest    4fab981df737  2 years ago   4.69 MB
[user@host podman-py]$ podman ps -a
CONTAINER ID  IMAGE   COMMAND  CREATED  STATUS  PORTS   NAMES
[user@host podman-py]$ podman pod ls
POD ID  NAME    STATUS  CREATED  INFRA ID  # OF CONTAINERS
[user@host podman-py]$ 
```
