### PR TITLE
Allow passing all available options to volume mount

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -220,12 +220,12 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                 a dictionary with the keys:
 
                 - bind: The path to mount the volume inside the container
-                - mode: Either rw to mount the volume read/write, or ro to mount it read-only.
+                - options: Options are options that the named volume will be mounted with
 
                 For example:
 
-                    {'/home/user1/': {'bind': '/mnt/vol2', 'mode': 'rw'},
-                     '/var/www': {'bind': '/mnt/vol1', 'mode': 'ro'}}
+                    {'/home/user1/': {'bind': '/mnt/vol2', 'options': ['rw']},
+                     '/var/www': {'bind': '/mnt/vol1', 'options': ['ro', 'noexec']}}
 
             volumes_from (List[str]): List of container names or IDs to get volumes from.
             working_dir (str): Path to the working directory.
@@ -539,7 +539,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             volume = {
                 "Name": key,
                 "Dest": value["bind"],
-                "Options": [value["mode"]] if "mode" in value else [],
+                "Options": value["options"] if type(value.get("options")) is list else [],
             }
             params["volumes"].append(volume)
 

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -215,17 +215,26 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             version (str): The version of the API to use. Set to auto to automatically detect
                 the server's version. Default: 3.0.0
             volume_driver (str): The name of a volume driver/plugin.
-            volumes (Dict[str, Dict[str, str]]): A dictionary to configure volumes mounted inside
-                the container. The key is either the host path or a volume name, and the value is
+            volumes (Dict[str, Dict[str, Union[str, list]]]): A dictionary to configure
+                volumes mounted inside the container.
+                The key is either the host path or a volume name, and the value is
                 a dictionary with the keys:
 
                 - bind: The path to mount the volume inside the container
-                - options: Options are options that the named volume will be mounted with
+                - mode: Either rw to mount the volume read/write, or ro to mount it read-only.
+                        Kept for docker-py compatibility
+                - extended_mode: List of options passed to volume mount.
 
                 For example:
 
-                    {'/home/user1/': {'bind': '/mnt/vol2', 'options': ['rw']},
-                     '/var/www': {'bind': '/mnt/vol1', 'options': ['ro', 'noexec']}}
+                    {
+                        'test_bind_1':
+                            {'bind': '/mnt/vol1', 'mode': 'rw'},
+                        'test_bind_2':
+                            {'bind': '/mnt/vol2', 'extended_mode': ['ro', 'noexec']},
+                         'test_bind_3':
+                            {'bind': '/mnt/vol3', 'extended_mode': ['noexec'], 'mode': 'rw'}
+                    }
 
             volumes_from (List[str]): List of container names or IDs to get volumes from.
             working_dir (str): Path to the working directory.
@@ -536,11 +545,18 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
 
         for item in args.pop("volumes", {}).items():
             key, value = item
-            volume = {
-                "Name": key,
-                "Dest": value["bind"],
-                "Options": value["options"] if type(value.get("options")) is list else [],
-            }
+            extended_mode = value.get('extended_mode', [])
+            if not isinstance(extended_mode, list):
+                raise ValueError("'extended_mode' value should be a list")
+
+            options = extended_mode
+            mode = value.get('mode')
+            if mode is not None:
+                if not isinstance(mode, str):
+                    raise ValueError("'mode' value should be a str")
+                options.append(mode)
+
+            volume = {"Name": key, "Dest": value["bind"], "Options": options}
             params["volumes"].append(volume)
 
         if "cgroupns" in args:

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -71,7 +71,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             proper_container.start()
             proper_container.wait()
             logs = b"\n".join(proper_container.logs()).decode()
-            formatted_hosts = [f"{ip} {hosts}" for hosts, ip in extra_hosts.items()]
+            formatted_hosts = [f"{ip}\t{hosts}" for hosts, ip in extra_hosts.items()]
             for hosts_entry in formatted_hosts:
                 self.assertIn(hosts_entry, logs)
 


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>


Right now it is possible only to pass mode to mounted volume during container creation. I have no idea what was the reasoning behind it but the Podman REST API is capable of passing more options.

I'm only concerned about backward compatibility : 

- In docker-py option was called mode but there was possibility to pass multiple arguments (e.g. `z,ro`)
- I've renamed option `mode` -> `options` to be more precise what this option is actually doing so there is actually no backward compatibility with podman-py. Maybe this option should still be named `mode` and accept strings as well as list (?) - no idea whether it has to be backward compatible, if not, it is better to rename it.


```
>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> c1 = client.containers.create(name='test_noexec', image='test_image', volumes={"test_volume": {"bind": "/m", "options": ["rw", "noexec"]}}, command=['/bin/sleep', '12345'])
>>> c1.start()
>>> c2 = client.containers.create(name='test_exec', image='test_image', volumes={"test_volume": {"bind": "/m", "options": ["rw", "exec"]}}, command=['/bin/sleep', '12345'])
>>> c2.start()
>>> c1.attrs['HostConfig']['Binds']
['test_volume:/m:rw,noexec,rprivate,nosuid,nodev,rbind']
>>> c2.attrs['HostConfig']['Binds']
['test_volume:/m:rw,exec,rprivate,nosuid,nodev,rbind']

...

[root@host ~]# podman exec test_exec cp /bin/true /m/
[root@host ~]# podman exec -ti test_noexec /m/true
Error: exec failed: container_linux.go:380: starting container process caused: permission denied: OCI permission denied
[root@host ~]# podman exec -ti test_exec /m/true
[root@host ~]#
```

Ran 277 tests in 40.010s

FAILED (SKIP=3, errors=4, failures=4)
