### PR TITLE
Fixup lint items

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -142,7 +142,10 @@ disable=print-statement,
         comprehension-escape,
         no-self-use,
         no-member, # PyCQA/pylint#3157
-        too-many-public-methods # tests can have many members
+        too-many-public-methods, # tests can have many members
+        fixme, # don't warn on fixme stuff
+        duplicate-code, # current CI version doesn't honor the minimum for some reason
+        bad-option-value # needed until pylint version is increased to a version with it
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -378,6 +381,7 @@ function-naming-style=snake_case
 good-names=c,
            e,
            i,
+           ip,
            j,
            k,
            r,
@@ -444,7 +448,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [VARIABLES]

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -140,7 +140,7 @@ class APIClient(requests.Session):
 
         self.timeout = timeout
         self.pool_maxsize = num_pools or requests.adapters.DEFAULT_POOLSIZE
-        self.credstore_env = credstore_env or dict()
+        self.credstore_env = credstore_env or {}
 
         self.user_agent = user_agent or (
             f"PodmanPy/{__version__} (API v{self.version}; Compatible v{self.compatible_version})"
@@ -374,7 +374,7 @@ class APIClient(requests.Session):
             APIError: when service returns an error
         """
         # Only set timeout if one is given, lower level APIs will not override None
-        timeout_kw = dict()
+        timeout_kw = {}
         timeout = timeout or self.timeout
         if timeout_kw is not None:
             timeout_kw["timeout"] = timeout
@@ -402,7 +402,7 @@ class APIClient(requests.Session):
                     uri.geturl(),
                     params=params,
                     data=data,
-                    headers=(headers or dict()),
+                    headers=(headers or {}),
                     stream=stream,
                     **timeout_kw,
                 )

--- a/podman/api/http_utils.py
+++ b/podman/api/http_utils.py
@@ -10,7 +10,7 @@ def prepare_filters(filters: Union[str, List[str], Mapping[str, str]]) -> Option
     if filters is None or len(filters) == 0:
         return None
 
-    criteria: Dict[str, List[str]] = dict()
+    criteria: Dict[str, List[str]] = {}
     if isinstance(filters, str):
         _format_string(filters, criteria)
     elif isinstance(filters, collections.abc.Mapping):
@@ -70,7 +70,7 @@ def _filter_values(mapping: Mapping[str, Any]) -> Dict[str, Any]:
 
     Dictionary is walked using recursion.
     """
-    canonical = dict()
+    canonical = {}
     for key, value in mapping.items():
         # quick filter if possible...
         if value is None or (isinstance(value, collections.abc.Sized) and len(value) <= 0):
@@ -84,7 +84,7 @@ def _filter_values(mapping: Mapping[str, Any]) -> Dict[str, Any]:
         else:
             proposal = value
 
-        if proposal not in (None, str(), list(), dict()):
+        if proposal not in (None, str(), [], {}):
             canonical[key] = proposal
 
     return canonical

--- a/podman/api/parse_utils.py
+++ b/podman/api/parse_utils.py
@@ -32,7 +32,7 @@ def parse_repository(name: str) -> Tuple[str, Optional[str]]:
 def decode_header(value: Optional[str]) -> Dict[str, Any]:
     """Decode a base64 JSON header value."""
     if value is None:
-        return dict()
+        return {}
 
     value = base64.b64decode(value)
     text = value.decode("utf-8")

--- a/podman/api/ssh.py
+++ b/podman/api/ssh.py
@@ -16,12 +16,13 @@ from typing import Optional, Union
 
 import time
 import xdg.BaseDirectory
-from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_RETRIES, HTTPAdapter
 
 try:
     import urllib3
 except ImportError:
-    import requests.packages.urllib3 as urllib3
+    from requests.packages import urllib3
+
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_RETRIES, HTTPAdapter
 
 from .adapter_utils import _key_normalizer
 
@@ -74,7 +75,7 @@ class SSHSocket(socket.socket):
             command += ["-i", str(path)]
 
         command += [f"ssh://{uri.netloc}"]
-        self._proc = subprocess.Popen(
+        self._proc = subprocess.Popen(  # pylint: disable=consider-using-with
             command,
             shell=False,
             stdout=subprocess.PIPE,

--- a/podman/api/tar_utils.py
+++ b/podman/api/tar_utils.py
@@ -20,7 +20,7 @@ def prepare_containerignore(anchor: str) -> List[str]:
         if not ignore.exists():
             continue
 
-        with ignore.open() as file:
+        with ignore.open(encoding='utf-8') as file:
             return list(
                 filter(
                     lambda l: l and not l.startswith("#"),
@@ -97,7 +97,9 @@ def create_tar(
         return info
 
     if name is None:
-        name = tempfile.NamedTemporaryFile(prefix="podman_context", suffix=".tar")
+        name = tempfile.NamedTemporaryFile(
+            prefix="podman_context", suffix=".tar"
+        )  # pylint: disable=consider-using-with
     else:
         name = pathlib.Path(name)
 
@@ -114,7 +116,7 @@ def create_tar(
     with tarfile.open(name.name, mode) as tar:
         tar.add(anchor, arcname="", recursive=True, filter=add_filter)
 
-    return open(name.name, "rb")
+    return open(name.name, "rb")  # pylint: disable=consider-using-with
 
 
 def _exclude_matcher(path: str, exclude: List[str]) -> bool:

--- a/podman/api/typing_extensions.py
+++ b/podman/api/typing_extensions.py
@@ -884,7 +884,6 @@ elif _geqv_defined:
                 return collections.deque(*args, **kwds)
             return _generic_new(collections.deque, cls, *args, **kwds)
 
-
 else:
 
     class Deque(
@@ -911,7 +910,6 @@ elif hasattr(contextlib, 'AbstractContextManager'):
         extra=contextlib.AbstractContextManager,
     ):
         __slots__ = ()
-
 
 else:
 
@@ -994,7 +992,6 @@ elif _geqv_defined:
                 return collections.defaultdict(*args, **kwds)
             return _generic_new(collections.defaultdict, cls, *args, **kwds)
 
-
 else:
 
     class DefaultDict(
@@ -1031,7 +1028,6 @@ elif _geqv_defined:
             if _geqv(cls, OrderedDict):
                 return collections.OrderedDict(*args, **kwds)
             return _generic_new(collections.OrderedDict, cls, *args, **kwds)
-
 
 else:
 
@@ -1073,7 +1069,6 @@ elif (3, 5, 0) <= sys.version_info[:3] <= (3, 5, 1):
                 return collections.Counter(*args, **kwds)
             return _generic_new(collections.Counter, cls, *args, **kwds)
 
-
 elif _geqv_defined:
 
     class Counter(
@@ -1089,7 +1084,6 @@ elif _geqv_defined:
             if _geqv(cls, Counter):
                 return collections.Counter(*args, **kwds)
             return _generic_new(collections.Counter, cls, *args, **kwds)
-
 
 else:
 
@@ -2101,7 +2095,6 @@ elif PEP_560:
             return hint
         return {k: _strip_annotations(t) for k, t in hint.items()}
 
-
 elif HAVE_ANNOTATED:
 
     def _is_dunder(name):
@@ -2336,7 +2329,6 @@ elif sys.version_info[:2] >= (3, 9):
         It's invalid when used anywhere except as in the example above.
         """
         raise TypeError("{} is not subscriptable".format(self))
-
 
 elif sys.version_info[:2] >= (3, 7):
 
@@ -2665,7 +2657,6 @@ elif sys.version_info[:2] >= (3, 9):
         """
         return _concatenate_getitem(self, parameters)
 
-
 elif sys.version_info[:2] >= (3, 7):
 
     class _ConcatenateForm(typing._SpecialForm, _root=True):
@@ -2813,7 +2804,6 @@ elif sys.version_info[:2] >= (3, 9):
         """
         item = typing._type_check(parameters, '{} accepts only single type.'.format(self))
         return _GenericAlias(self, (item,))
-
 
 elif sys.version_info[:2] >= (3, 7):
 

--- a/podman/api/uds.py
+++ b/podman/api/uds.py
@@ -7,14 +7,14 @@ import socket
 from typing import Optional, Union
 from urllib.parse import unquote, urlparse
 
-from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
-
-from ..errors import APIError
-
 try:
     import urllib3
 except ImportError:
-    import requests.packages.urllib3 as urllib3
+    from requests.packages import urllib3
+
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
+
+from ..errors import APIError
 
 from .adapter_utils import _key_normalizer
 

--- a/podman/api_connection.py
+++ b/podman/api_connection.py
@@ -8,10 +8,10 @@ from contextlib import AbstractContextManager
 from http import HTTPStatus
 from http.client import HTTPConnection
 
-import podman.containers as containers
-import podman.errors as errors
-import podman.images as images
-import podman.system as system
+from podman import containers
+from podman import errors
+from podman import images
+from podman import system
 
 
 class ApiConnection(HTTPConnection, AbstractContextManager):
@@ -29,7 +29,7 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
         uri = urllib.parse.urlparse(url)
         if uri.scheme not in supported_schemes:
             raise ValueError(
-                "The scheme '{}' is not supported, only {}".format(uri.scheme, supported_schemes)
+                f"The scheme '{uri.scheme}' is not supported, only {supported_schemes}"
             )
         self.uri = uri
         self.base = base
@@ -42,7 +42,7 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
             sock.connect(self.uri.path)
             self.sock = sock
         else:
-            raise NotImplementedError("Scheme {} not yet implemented".format(self.uri.scheme))
+            raise NotImplementedError(f"Scheme {self.uri.scheme} not yet implemented")
 
     def delete(self, path, params=None):
         """Basic DELETE wrapper for requests
@@ -105,7 +105,7 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
             pass
         elif HTTPStatus.NOT_FOUND == response.status:
             raise errors.NotFoundError(
-                "Request {}:{} failed: {}".format(
+                "Request {}:{} failed: {}".format(  # pylint: disable=consider-using-f-string
                     method,
                     url,
                     HTTPStatus.NOT_FOUND.description or HTTPStatus.NOT_FOUND.phrase,
@@ -117,10 +117,10 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
             and response.status < HTTPStatus.INTERNAL_SERVER_ERROR
         ):
             raise errors.RequestError(
-                "Request {}:{} failed: {}".format(
+                "Request {}:{} failed: {}".format(  # pylint: disable=consider-using-f-string
                     method,
                     url,
-                    response.reason or "Response Status Code {}".format(response.status),
+                    response.reason or f"Response Status Code {response.status}",
                 ),
                 response,
             )
@@ -134,7 +134,7 @@ class ApiConnection(HTTPConnection, AbstractContextManager):
                     or HTTPStatus.INTERNAL_SERVER_ERROR.phrase
                 )
             raise errors.InternalServerError(
-                "Request {}:{} failed: {}".format(method, url, error_message),
+                f"Request {method}:{url} failed: {error_message}",
                 response,
             )
         return response

--- a/podman/client.py
+++ b/podman/client.py
@@ -115,7 +115,7 @@ class PodmanClient(AbstractContextManager):
             Client used to communicate with a Podman service.
         """
         environment = environment or os.environ
-        credstore_env = credstore_env or dict()
+        credstore_env = credstore_env or {}
 
         if version == "auto":
             version = None

--- a/podman/containers/__init__.py
+++ b/podman/containers/__init__.py
@@ -4,7 +4,7 @@
 import json
 from http import HTTPStatus
 
-import podman.errors as errors
+from podman import errors
 
 
 def attach(api, name):
@@ -15,10 +15,10 @@ def attach(api, name):
 def changes(api, name):
     """Get files added, deleted or modified in a container"""
     try:
-        response = api.get('/containers/{}/changes'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/containers/{api.quote(name)}/changes')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def checkpoint(
@@ -31,7 +31,7 @@ def checkpoint(
     tcp_established=None,
 ):
     """Copy tar of files into a container"""
-    path = '/containers/{}/checkpoint'.format(api.quote(name))
+    path = f'/containers/{api.quote(name)}/checkpoint'
     params = {}
     if export_image is not None:
         params['export'] = export_image
@@ -45,29 +45,29 @@ def checkpoint(
         params['tcpEstablished'] = tcp_established
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
-        return response.read()
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.read()
 
 
 def copy(api, name, file_path, pause_container=None):
     """Copy tar of files into a container"""
-    path = '/containers/{}/copy'.format(api.quote(name))
+    path = f'/containers/{api.quote(name)}/copy'
     params = {'path': file_path}
     if pause_container is not None:
         params['pause'] = pause_container
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
         response.read()
-        return True
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return True
 
 
 def container_exists(api, name):
     """Check if container exists"""
     try:
-        api.get("/containers/{}/exists".format(api.quote(name)))
+        api.get(f"/containers/{api.quote(name)}/exists")
         return True
     except errors.NotFoundError:
         return False
@@ -87,27 +87,27 @@ def create(api, container_data):
             headers={'content-type': 'application/json'},
         )
         response.read()
-        return response.status == HTTPStatus.CREATED
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.CREATED
 
 
 def export(api, name):
     """Container export"""
     try:
-        response = api.get("/containers/{}/export".format(api.quote(name)))
-        return response.read()
+        response = api.get(f"/containers/{api.quote(name)}/export")
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.read()
 
 
 def healthcheck(api, name):
     """Execute container healthcheck"""
     try:
-        response = api.get('/containers/{}/healthcheck'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/containers/{api.quote(name)}/healthcheck')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def init(api, name):
@@ -116,11 +116,11 @@ def init(api, name):
     Returns true if successful, false if already done
     """
     try:
-        response = api.post('/containers/{}/init'.format(api.quote(name)))
+        response = api.post(f'/containers/{api.quote(name)}/init')
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def inspect(api, name):
@@ -128,15 +128,15 @@ def inspect(api, name):
     Name may also be a container ID.
     """
     try:
-        response = api.get('/containers/{}/json'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/containers/{api.quote(name)}/json')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def kill(api, name, signal=None):
     """kill named/identified container"""
-    path = "/containers/{}/kill".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/kill"
     params = {}
     if signal is not None:
         params = {'signal': signal}
@@ -145,9 +145,9 @@ def kill(api, name, signal=None):
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
         # returns an empty bytes object
         response.read()
-        return True
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return True
 
 
 def list_containers(api, all_=None, filters=None, limit=None, size=None, sync=None):
@@ -175,28 +175,28 @@ def logs(api, name, follow=None, since=None, stderr=None, tail=None, timestamps=
 
 def mount(api, name):
     """Mount container to the filesystem"""
-    path = "/containers/{}/mount".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/mount"
     try:
         response = api.post(path, headers={'content-type': 'application/json'})
-        return json.loads(str(response.read(), "utf-8"))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), "utf-8"))
 
 
 def pause(api, name):
     """Pause a container"""
-    path = "/containers/{}/pause".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/pause"
     try:
         response = api.post(path, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def prune(api, name, filters=None):
     """Remove stopped containers"""
-    path = "/containers/{}/prune".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/prune"
     params = {}
     if filters is not None:
         params['filters'] = filters
@@ -206,7 +206,7 @@ def prune(api, name, filters=None):
 
 def remove(api, name, force=None, delete_volumes=None):
     """Delete container"""
-    path = "/containers/{}".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}"
     params = {}
     if force is not None:
         params['force'] = force
@@ -217,34 +217,34 @@ def remove(api, name, force=None, delete_volumes=None):
         response = api.delete(path, params)
         # returns an empty bytes object
         response.read()
-        return True
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return True
 
 
 def resize(api, name, height, width):
     """Resize container tty"""
-    path = "/containers/{}/resize".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/resize"
     params = {'h': height, 'w': width}
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def restart(api, name, timeout=None):
     """Restart container"""
-    path = "/containers/{}/restart".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/restart"
     params = {}
     if timeout is not None:
         params['t'] = timeout
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def restore(
@@ -260,7 +260,7 @@ def restore(
     tcp_established=None,
 ):
     """Restore container"""
-    path = "/containers/{}/restore".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/restore"
     params = {}
     if ignore_root_fs is not None:
         params['ignoreRootFS'] = ignore_root_fs
@@ -280,10 +280,10 @@ def restore(
         params['tcpEstablished'] = tcp_established
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
-        # TODO(mwhahaha): handle returned tarball better
-        return response.read()
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    # TODO(mwhahaha): handle returned tarball better
+    return response.read()
 
 
 def show_mounted(api):
@@ -294,16 +294,16 @@ def show_mounted(api):
 
 def start(api, name, detach_keys=None):
     """Start container"""
-    path = "/containers/{}/start".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/start"
     params = {}
     if detach_keys is not None:
         params['detachKeys'] = detach_keys
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def stats(api, containers=None, stream=True):
@@ -319,23 +319,23 @@ def stats(api, containers=None, stream=True):
         response = api.get(path, params=params)
         if stream:
             return response
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def stop(api, name, timeout=None):
     """Stop container"""
-    path = "/containers/{}/stop".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/stop"
     params = {}
     if timeout is not None:
         params['t'] = timeout
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def top(api, name, ps_args=None, stream=True):
@@ -343,7 +343,7 @@ def top(api, name, ps_args=None, stream=True):
 
     When stream is set to true, the raw HTTPResponse is returned.
     """
-    path = "/containers/{}/top".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/top"
     params = {'stream': stream}
     if ps_args is not None:
         params['ps_args'] = ps_args
@@ -351,44 +351,44 @@ def top(api, name, ps_args=None, stream=True):
         response = api.get(path, params=params)
         if stream:
             return response
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def unmount(api, name):
     """Unmount container"""
-    path = "/containers/{}/unmount".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/unmount"
     try:
         response = api.post(path, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def unpause(api, name):
     """Unpause container"""
-    path = "/containers/{}/unpause".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/unpause"
     try:
         response = api.post(path, headers={'content-type': 'application/json'})
         response.read()
-        return response.status == HTTPStatus.NO_CONTENT
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return response.status == HTTPStatus.NO_CONTENT
 
 
 def wait(api, name, condition=None):
     """Wait for a container state"""
-    path = "/containers/{}/wait".format(api.quote(name))
+    path = f"/containers/{api.quote(name)}/wait"
     params = {}
     if condition is not None:
         params['condition'] = condition
     try:
         response = api.post(path, params=params, headers={'content-type': 'application/json'})
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ContainerNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 __all__ = [

--- a/podman/domain/config.py
+++ b/podman/domain/config.py
@@ -60,9 +60,9 @@ class PodmanConfig:
         else:
             self.path = Path(path)
 
-        self.attrs = dict()
+        self.attrs = {}
         if self.path.exists():
-            with self.path.open() as file:
+            with self.path.open(encoding='utf-8') as file:
                 buffer = file.read()
             self.attrs = toml.loads(buffer)
 
@@ -88,7 +88,7 @@ class PodmanConfig:
             address = podman_config.services["testing"]
             print(f"Testing service address {address}")
         """
-        services: Dict[str, ServiceConnection] = dict()
+        services: Dict[str, ServiceConnection] = {}
 
         engine = self.attrs.get("engine")
         if engine:

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -27,8 +27,7 @@ class Container(PodmanResource):
         with suppress(KeyError):
             if 'Name' in self.attrs:
                 return self.attrs["Name"].lstrip("/")
-            else:
-                return self.attrs["Names"][0].lstrip("/")
+            return self.attrs["Names"][0].lstrip("/")
         return None
 
     @property
@@ -45,7 +44,7 @@ class Container(PodmanResource):
         """dict[str, str]: Returns labels associated with container."""
         with suppress(KeyError):
             return self.attrs["Config"]["Labels"]
-        return dict()
+        return {}
 
     @property
     def status(self):
@@ -59,7 +58,7 @@ class Container(PodmanResource):
         """dict[str, int]: Return ports exposed by container."""
         with suppress(KeyError):
             return self.attrs["NetworkSettings"]["Ports"]
-        return dict()
+        return {}
 
     def attach(self, **kwargs) -> Union[str, Iterator[str]]:
         """Attach to container's tty.
@@ -345,7 +344,7 @@ class Container(PodmanResource):
             timeout (int): Seconds to wait for container to stop before killing container.
         """
         params = {"timeout": kwargs.get("timeout")}
-        post_kwargs = dict()
+        post_kwargs = {}
         if kwargs.get("timeout"):
             post_kwargs["timeout"] = float(params["timeout"]) * 1.5
 
@@ -415,7 +414,7 @@ class Container(PodmanResource):
         """
         params = {"all": kwargs.get("all"), "timeout": kwargs.get("timeout")}
 
-        post_kwargs = dict()
+        post_kwargs = {}
         if kwargs.get("timeout"):
             post_kwargs["timeout"] = float(params["timeout"]) * 1.5
 

--- a/podman/domain/containers_manager.py
+++ b/podman/domain/containers_manager.py
@@ -26,7 +26,9 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         return response.ok
 
     # pylint is flagging 'container_id' here vs. 'key' parameter in super.get()
-    def get(self, container_id: str) -> Container:  # pylint: disable=arguments-differ
+    def get(
+        self, container_id: str
+    ) -> Container:  # pylint: disable=arguments-differ,arguments-renamed
         """Get container by name or id.
 
         Args:
@@ -71,7 +73,7 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         """
         params = {
             "all": kwargs.get("all"),
-            "filters": kwargs.get("filters", dict()),
+            "filters": kwargs.get("filters", {}),
             "limit": kwargs.get("limit"),
         }
         if "before" in kwargs:
@@ -107,7 +109,7 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         response = self.client.post("/containers/prune", params=params)
         response.raise_for_status()
 
-        results = {"ContainersDeleted": list(), "SpaceReclaimed": 0}
+        results = {"ContainersDeleted": [], "SpaceReclaimed": 0}
         for entry in response.json():
             if entry.get("error") is not None:
                 raise APIError(entry["error"], response=response, explanation=entry["error"])

--- a/podman/domain/images.py
+++ b/podman/domain/images.py
@@ -20,7 +20,7 @@ class Image(PodmanResource):
         """dict[str, str]: Return labels associated with Image."""
         image_labels = self.attrs.get("Labels")
         if image_labels is None or len(image_labels) == 0:
-            return dict()
+            return {}
 
         return image_labels
 
@@ -29,7 +29,7 @@ class Image(PodmanResource):
         """list[str]: Return tags from Image."""
         repo_tags = self.attrs.get("RepoTags")
         if repo_tags is None or len(repo_tags) == 0:
-            return list()
+            return []
 
         return [tag for tag in repo_tags if tag != "<none>:<none>"]
 

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -78,10 +78,10 @@ class BuildMixin:
         body = None
         path = None
         if "fileobj" in kwargs:
-            path = tempfile.TemporaryDirectory()
+            path = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
             filename = pathlib.Path(path.name) / params["dockerfile"]
 
-            with open(filename, "w") as file:
+            with open(filename, "w", encoding='utf-8') as file:
                 shutil.copyfileobj(kwargs["fileobj"], file)
             body = api.create_tar(anchor=path.name, gzip=kwargs.get("gzip", False))
         elif "path" in kwargs:
@@ -94,7 +94,7 @@ class BuildMixin:
                 anchor=kwargs["path"], exclude=excludes, gzip=kwargs.get("gzip", False)
             )
 
-        post_kwargs = dict()
+        post_kwargs = {}
         if kwargs.get("timeout"):
             post_kwargs["timeout"] = float(kwargs.get("timeout"))
 

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -59,7 +59,7 @@ class ImagesManager(BuildMixin, Manager):
         return [self.prepare_model(attrs=i) for i in response.json()]
 
     # pylint is flagging 'name' here vs. 'key' parameter in super.get()
-    def get(self, name: str) -> Image:  # pylint: disable=arguments-differ
+    def get(self, name: str) -> Image:  # pylint: disable=arguments-differ,arguments-renamed
         """Returns an image by name or id.
 
         Args:

--- a/podman/domain/ipam.py
+++ b/podman/domain/ipam.py
@@ -53,8 +53,8 @@ class IPAMConfig(dict):
         super().__init__()
         self.update(
             {
-                "Config": pool_configs or list(),
+                "Config": pool_configs or [],
                 "Driver": driver,
-                "Options": options or dict(),
+                "Options": options or {},
             }
         )

--- a/podman/domain/manager.py
+++ b/podman/domain/manager.py
@@ -33,7 +33,7 @@ class PodmanResource(ABC):
         self.client = client
         self.manager = collection
 
-        self.attrs = dict()
+        self.attrs = {}
         if attrs is not None:
             self.attrs.update(attrs)
 
@@ -104,7 +104,7 @@ class Manager(ABC):
         """Returns list of resources."""
 
     def prepare_model(self, attrs: Union[PodmanResource, Mapping[str, Any]]) -> PodmanResourceType:
-        """ Create a model from a set of attributes. """
+        """Create a model from a set of attributes."""
 
         # Refresh existing PodmanResource.
         if isinstance(attrs, PodmanResource):

--- a/podman/domain/manifests.py
+++ b/podman/domain/manifests.py
@@ -39,7 +39,7 @@ class Manifest(PodmanResource):
 
     @property
     def names(self):
-        """ List[str]: Returns the identifier of the manifest."""
+        """List[str]: Returns the identifier of the manifest."""
         return self.attrs.get("names")
 
     @property
@@ -76,7 +76,7 @@ class Manifest(PodmanResource):
             "annotation": kwargs.get("annotation"),
             "arch": kwargs.get("arch"),
             "features": kwargs.get("features"),
-            "images": list(),
+            "images": [],
             "os": kwargs.get("os"),
             "os_version": kwargs.get("os_version"),
             "variant": kwargs.get("variant"),
@@ -167,7 +167,7 @@ class ManifestsManager(Manager):
 
         params = {"name": names}
         if images is not None:
-            params["image"] = list()
+            params["image"] = []
             for item in images:
                 if isinstance(item, Image):
                     item = item.attrs["RepoTags"][0]
@@ -184,7 +184,7 @@ class ManifestsManager(Manager):
         manifest.attrs["names"] = names
 
         if manifest.attrs["manifests"] is None:
-            manifest.attrs["manifests"] = list()
+            manifest.attrs["manifests"] = []
         return manifest
 
     def exists(self, key: str) -> bool:

--- a/podman/domain/networks.py
+++ b/podman/domain/networks.py
@@ -38,11 +38,11 @@ class Network(PodmanResource):
 
     @property
     def containers(self):
-        """ List[Container]: Returns list of Containers connected to network."""
+        """List[Container]: Returns list of Containers connected to network."""
         with suppress(KeyError):
             container_manager = ContainersManager(client=self.client)
             return [container_manager.get(ident) for ident in self.attrs["Containers"].keys()]
-        return dict()
+        return {}
 
     @property
     def name(self):

--- a/podman/domain/networks_manager.py
+++ b/podman/domain/networks_manager.py
@@ -164,7 +164,7 @@ class NetworksManager(Manager):
         """
         compatible = kwargs.get("compatible", True)
 
-        filters = kwargs.get("filters", dict())
+        filters = kwargs.get("filters", {})
         filters["name"] = kwargs.get("names")
         filters["id"] = kwargs.get("ids")
         filters = api.prepare_filters(filters)
@@ -204,7 +204,7 @@ class NetworksManager(Manager):
         if compatible:
             return body
 
-        deleted: List[str] = list()
+        deleted: List[str] = []
         for item in body:
             if item["Error"] is not None:
                 raise APIError(

--- a/podman/domain/pods_manager.py
+++ b/podman/domain/pods_manager.py
@@ -27,7 +27,7 @@ class PodsManager(Manager):
                 https://docs.podman.io/en/latest/_static/api.html#operation/CreatePod] for
                 complete list of keywords.
         """
-        data = dict() if kwargs is None else kwargs.copy()
+        data = {} if kwargs is None else kwargs.copy()
         data["name"] = name
 
         response = self.client.post("/pods/create", data=json.dumps(data))
@@ -42,7 +42,7 @@ class PodsManager(Manager):
         return response.ok
 
     # pylint is flagging 'pod_id' here vs. 'key' parameter in super.get()
-    def get(self, pod_id: str) -> Pod:  # pylint: disable=arguments-differ
+    def get(self, pod_id: str) -> Pod:  # pylint: disable=arguments-differ,arguments-renamed
         """Return information for Pod by name or id.
 
         Args:
@@ -97,7 +97,7 @@ class PodsManager(Manager):
         response = self.client.post("/pods/prune", params={"filters": api.prepare_filters(filters)})
         response.raise_for_status()
 
-        deleted: List[str] = list()
+        deleted: List[str] = []
         for item in response.json():
             if item["Err"] is not None:
                 raise APIError(

--- a/podman/domain/secrets.py
+++ b/podman/domain/secrets.py
@@ -60,7 +60,7 @@ class SecretsManager(Manager):
         return response.ok
 
     # pylint is flagging 'secret_id' here vs. 'key' parameter in super.get()
-    def get(self, secret_id: str) -> Secret:  # pylint: disable=arguments-differ
+    def get(self, secret_id: str) -> Secret:  # pylint: disable=arguments-differ,arguments-renamed
         """Return information for Secret by name or id.
 
         Args:

--- a/podman/domain/volumes.py
+++ b/podman/domain/volumes.py
@@ -77,7 +77,7 @@ class VolumesManager(Manager):
         return response.ok
 
     # pylint is flagging 'volume_id' here vs. 'key' parameter in super.get()
-    def get(self, volume_id: str) -> Volume:  # pylint: disable=arguments-differ
+    def get(self, volume_id: str) -> Volume:  # pylint: disable=arguments-differ,arguments-renamed
         """Returns and volume by name or id.
 
         Args:
@@ -125,7 +125,7 @@ class VolumesManager(Manager):
         data = response.json()
         response.raise_for_status()
 
-        volumes: List[str] = list()
+        volumes: List[str] = []
         space_reclaimed = 0
         for item in data:
             if "Err" in item:

--- a/podman/images/__init__.py
+++ b/podman/images/__init__.py
@@ -2,7 +2,7 @@
 import json
 from http import HTTPStatus
 
-import podman.errors as errors
+from podman import errors
 
 
 def list_images(api):
@@ -16,32 +16,32 @@ def inspect(api, name):
     Name may also be an image ID.
     """
     try:
-        response = api.get("/images/{}/json".format(api.quote(name)))
-        return json.loads(str(response.read(), "utf-8"))
+        response = api.get(f"/images/{api.quote(name)}/json")
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response)
+    return json.loads(str(response.read(), "utf-8"))
 
 
 def image_exists(api, name):
     """Checks if an image exists in the local store"""
     try:
-        api.get("/images/{}/exists".format(api.quote(name)))
-        return True
+        api.get(f"/images/{api.quote(name)}/exists")
     except errors.NotFoundError:
         return False
+    return True
 
 
 def remove(api, name, force=None):
     """Remove named/identified image from Podman storage."""
     params = {}
-    path = "/images/{}".format(api.quote(name))
+    path = f"/images/{api.quote(name)}"
     if force is not None:
         params = {"force": force}
     try:
         response = api.delete(path, params)
-        return json.loads(str(response.read(), "utf-8"))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response)
+    return json.loads(str(response.read(), "utf-8"))
 
 
 def tag_image(api, name, repo, tag):
@@ -53,19 +53,19 @@ def tag_image(api, name, repo, tag):
     """
     data = {"repo": repo, "tag": tag}
     try:
-        response = api.post("/images/{}/tag".format(api.quote(name)), data)
-        return response.status == HTTPStatus.CREATED
+        response = api.post(f"/images/{api.quote(name)}/tag", data)
     except errors.NotFoundError as e:
         api.raise_image_not_found(e, e.response)
+    return response.status == HTTPStatus.CREATED
 
 
 def history(api, name):
     """get image history"""
     try:
-        response = api.get("/images/{}/history".format(api.quote(name)))
-        return json.loads(str(response.read(), "utf-8"))
+        response = api.get(f"/images/{api.quote(name)}/history")
     except errors.NotFoundError as e:
         api.raise_image_not_found(e, e.response)
+    return json.loads(str(response.read(), "utf-8"))
 
 
 __all__ = [

--- a/podman/manifests/__init__.py
+++ b/podman/manifests/__init__.py
@@ -16,17 +16,17 @@
 import json
 from http import HTTPStatus
 
-import podman.errors as errors
+from podman import errors
 
 
 def add(api, name, manifest):
     """Add image to a manifest list"""
-    path = '/manifests/{}/add'.format(api.quote(name))
+    path = f'/manifests/{api.quote(name)}/add'
     try:
         response = api.post(path, params=manifest, headers={'content-type': 'application/json'})
-        return response.status == HTTPStatus.OK
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ManifestNotFound)
+    return response.status == HTTPStatus.OK
 
 
 def create(api, name, image=None, all_contents=None):
@@ -39,18 +39,18 @@ def create(api, name, image=None, all_contents=None):
     path = '/manifests/create'
     try:
         response = api.post(path, params=params)
-        return response.status == HTTPStatus.OK
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ManifestNotFound)
+    return response.status == HTTPStatus.OK
 
 
 def inspect(api, name):
     """inspect a manifest"""
     try:
-        response = api.get('/manifests/{}/json'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/manifests/{api.quote(name)}/json')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ManifestNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def push(api, name, destination, all_images=None):
@@ -59,10 +59,10 @@ def push(api, name, destination, all_images=None):
     if all_images:
         params['all'] = all_images
     try:
-        response = api.post('/manifests/{}/push'.format(api.quote(name)), params=params)
-        return response.status == HTTPStatus.OK
+        response = api.post(f'/manifests/{api.quote(name)}/push', params=params)
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ManifestNotFound)
+    return response.status == HTTPStatus.OK
 
 
 def remove(api, name, digest=None):
@@ -70,12 +70,12 @@ def remove(api, name, digest=None):
     params = {}
     if digest:
         params['digest'] = digest
-    path = '/manifests/{}'.format(api.quote(name))
+    path = f'/manifests/{api.quote(name)}'
     try:
         response = api.delete(path, params)
-        return response.status == HTTPStatus.OK
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.ManifestNotFound)
+    return response.status == HTTPStatus.OK
 
 
 __all__ = [

--- a/podman/networks/__init__.py
+++ b/podman/networks/__init__.py
@@ -15,7 +15,7 @@
 """network provides the network operations for a Podman service"""
 import json
 
-import podman.errors as errors
+from podman import errors
 
 
 def create(api, name, network):
@@ -24,7 +24,7 @@ def create(api, name, network):
         data = json.dumps(network)
     else:
         data = network
-    path = '/networks/create?name={}'.format(api.quote(name))
+    path = f'/networks/create?name={api.quote(name)}'
     response = api.post(path, params=data, headers={'content-type': 'application/json'})
     return json.loads(str(response.read(), 'utf-8'))
 
@@ -32,10 +32,10 @@ def create(api, name, network):
 def inspect(api, name):
     """inspect a network"""
     try:
-        response = api.get('/networks/{}/json'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/networks/{api.quote(name)}/json')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.NetworkNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def list_networks(api, filters=None):
@@ -50,14 +50,14 @@ def list_networks(api, filters=None):
 def remove(api, name, force=None):
     """remove a named network"""
     params = {}
-    path = '/networks/{}'.format(api.quote(name))
+    path = f'/networks/{api.quote(name)}'
     if force is not None:
         params = {'force': force}
     try:
         response = api.delete(path, params)
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.NetworkNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def prune(api):

--- a/podman/pods/__init__.py
+++ b/podman/pods/__init__.py
@@ -15,7 +15,7 @@
 """pod provides the pod operations for a Podman service"""
 import json
 
-import podman.errors as errors
+from podman import errors
 
 
 def create(api, name, pod):
@@ -24,7 +24,7 @@ def create(api, name, pod):
         data = json.dumps(pod)
     else:
         data = pod
-    path = '/pods/create?name={}'.format(api.quote(name))
+    path = f'/pods/create?name={api.quote(name)}'
     response = api.post(path, params=data, headers={'content-type': 'application/json'})
     return json.loads(str(response.read(), 'utf-8'))
 
@@ -32,19 +32,19 @@ def create(api, name, pod):
 def exists(api, name):
     """inspect a pod"""
     try:
-        api.get('/pods/{}/exists'.format(api.quote(name)))
-        return True
+        api.get(f'/pods/{api.quote(name)}/exists')
     except errors.NotFoundError:
         return False
+    return True
 
 
 def inspect(api, name):
     """inspect a pod"""
     try:
-        response = api.get('/pods/{}/json'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.get(f'/pods/{api.quote(name)}/json')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def kill(api, name, signal=None):
@@ -53,10 +53,10 @@ def kill(api, name, signal=None):
     if signal:
         data['signal'] = signal
     try:
-        response = api.post('/pods/{}/kill'.format(api.quote(name)), data)
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.post(f'/pods/{api.quote(name)}/kill', data)
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def list_pods(api, filters=None):
@@ -76,17 +76,17 @@ def list_processes(api, name, stream=None, ps_args=None):
         params['stream'] = stream
     if ps_args:
         params['ps_args'] = ps_args
-    response = api.get('/pods/{}/top'.format(api.quote(name)), params)
+    response = api.get(f'/pods/{api.quote(name)}/top', params)
     return json.loads(str(response.read(), 'utf-8'))
 
 
 def pause(api, name):
     """pause a pod"""
     try:
-        response = api.post('/pods/{}/pause'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.post(f'/pods/{api.quote(name)}/pause')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def prune(api):
@@ -98,33 +98,33 @@ def prune(api):
 def remove(api, name, force=None):
     """Remove named/identified image from Podman storage."""
     params = {}
-    path = '/pods/{}'.format(api.quote(name))
+    path = f'/pods/{api.quote(name)}'
     if force is not None:
         params = {'force': force}
     try:
         response = api.delete(path, params)
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def restart(api, name):
     """restart a pod"""
     try:
-        response = api.post('/pods/{}/restart'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.post(f'/pods/{api.quote(name)}/restart')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def start(api, name):
     """start a pod"""
     try:
-        response = api.post('/pods/{}/start'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
-        # TODO(mwhahaha): handle 304 warning
+        response = api.post(f'/pods/{api.quote(name)}/start')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    # TODO(mwhahaha): handle 304 warning
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def stats(api, all_pods=True, pods=None):
@@ -134,28 +134,28 @@ def stats(api, all_pods=True, pods=None):
         params['namesOrIDs'] = pods
     try:
         response = api.post('/pods/stats', params)
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def stop(api, name):
     """stop a pod"""
     try:
-        response = api.post('/pods/{}/stop'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
-        # TODO(mwhahaha): handle 304 warning
+        response = api.post(f'/pods/{api.quote(name)}/stop')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    # TODO(mwhahaha): handle 304 warning
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def unpause(api, name):
     """unpause a pod"""
     try:
-        response = api.post('/pods/{}/unpause'.format(api.quote(name)))
-        return json.loads(str(response.read(), 'utf-8'))
+        response = api.post(f'/pods/{api.quote(name)}/unpause')
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response, errors.PodNotFound)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 __all__ = [

--- a/podman/system/__init__.py
+++ b/podman/system/__init__.py
@@ -3,7 +3,7 @@ import json
 import logging
 from http import HTTPStatus
 
-import podman.errors as errors
+from podman import errors
 
 
 def version(api, verify_version=False):
@@ -23,9 +23,9 @@ def get_info(api):
     """Returns information on the system and libpod configuration"""
     try:
         response = api.get("/info")
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 # this **looks** a lot like the above but is not equivalent - at all !
@@ -45,9 +45,9 @@ def show_disk_usage(api):
     """
     try:
         response = api.get("/system/df")
-        return json.loads(str(response.read(), 'utf-8'))
     except errors.NotFoundError as e:
         api.raise_not_found(e, e.response)
+    return json.loads(str(response.read(), 'utf-8'))
 
 
 def _report_not_found(e, response):

--- a/podman/tests/integration/base.py
+++ b/podman/tests/integration/base.py
@@ -20,7 +20,7 @@ import uuid
 
 import fixtures
 
-import podman.tests.integration.utils as utils
+from podman.tests.integration import utils
 
 
 class IntegrationTest(fixtures.TestWithFixtures):

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -33,7 +33,10 @@ class ContainersIntegrationTest(base.IntegrationTest):
             )
             self.containers.append(proper_container)
             formatted_hosts = [f"{hosts}:{ip}" for hosts, ip in extra_hosts.items()]
-            self.assertEqual(proper_container.attrs.get('HostConfig', dict()).get('ExtraHosts', list()), formatted_hosts)
+            self.assertEqual(
+                proper_container.attrs.get('HostConfig', dict()).get('ExtraHosts', list()),
+                formatted_hosts,
+            )
 
         with self.subTest("Check extra hosts in running container"):
             proper_container.start()
@@ -51,7 +54,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             {'value': '1234b', 'expected_value': 1234},
             {'value': '123k', 'expected_value': 123 * 1024},
             {'value': '44m', 'expected_value': 44 * 1024 * 1024},
-            {'value': '2g', 'expected_value': 2 * 1024 * 1024 * 1024}
+            {'value': '2g', 'expected_value': 2 * 1024 * 1024 * 1024},
         ]
 
         for test in memory_limit_tests:
@@ -59,7 +62,10 @@ class ContainersIntegrationTest(base.IntegrationTest):
                 self.alpine_image, **{parameter_name: test['value']}
             )
             self.containers.append(container)
-            self.assertEqual(container.attrs.get('HostConfig', dict()).get(host_config_name), test['expected_value'])
+            self.assertEqual(
+                container.attrs.get('HostConfig', dict()).get(host_config_name),
+                test['expected_value'],
+            )
 
     def test_container_kernel_memory(self):
         """Test passing kernel memory"""

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -2,6 +2,7 @@ import io
 import random
 import tarfile
 import unittest
+
 try:
     # Python >= 3.10
     from collections.abc import Iterator

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 
 import time
 
-import podman.tests.errors as errors
+from podman.tests import errors
 
 logger = logging.getLogger("podman.service")
 
@@ -93,7 +93,9 @@ class PodmanLauncher:
         def consume(line: str):
             logger.debug(line.strip("\n") + f" refid={self.reference_id}")
 
-        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.proc = subprocess.Popen(
+            self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )  # pylint: disable=consider-using-with
         threading.Thread(target=consume_lines, args=[self.proc.stdout, consume]).start()
 
         if not check_socket:

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -1,6 +1,7 @@
 import io
 import json
 import unittest
+
 try:
     # Python >= 3.10
     from collections.abc import Iterable

--- a/podman/tests/unit/test_config.py
+++ b/podman/tests/unit/test_config.py
@@ -49,7 +49,9 @@ class PodmanConfigTestCase(unittest.TestCase):
             self.assertEqual(config.active_service.url, expected)
             self.assertEqual(config.services["production"].identity, Path("/home/root/.ssh/id_rsa"))
 
-            PodmanConfigTestCase.opener.assert_called_with(Path("/home/developer/containers.conf"))
+            PodmanConfigTestCase.opener.assert_called_with(
+                Path("/home/developer/containers.conf"), encoding='utf-8'
+            )
 
 
 if __name__ == '__main__':

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -2,6 +2,7 @@ import base64
 import io
 import json
 import unittest
+
 try:
     # Python >= 3.10
     from collections.abc import Iterable

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -1,4 +1,5 @@
 import unittest
+
 try:
     # Python >= 3.10
     from collections.abc import Iterator
@@ -242,7 +243,7 @@ class ContainersManagerTestCase(unittest.TestCase):
         )
 
         with patch.multiple(Container, logs=DEFAULT, wait=DEFAULT, autospec=True) as mock_container:
-            mock_container["logs"].return_value = list()
+            mock_container["logs"].return_value = []
             mock_container["wait"].return_value = {"StatusCode": 0}
 
             actual = self.client.containers.run("fedora", "/usr/bin/ls", detach=True)

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -1,5 +1,6 @@
 import types
 import unittest
+
 try:
     # Python >= 3.10
     from collections.abc import Iterable

--- a/podman/tests/unit/test_podmanclient.py
+++ b/podman/tests/unit/test_podmanclient.py
@@ -89,7 +89,7 @@ class PodmanClientTestCase(unittest.TestCase):
 
             # Build path to support tests running as root or a user
             expected = Path(xdg.BaseDirectory.xdg_config_home) / "containers" / "containers.conf"
-            PodmanClientTestCase.opener.assert_called_with(expected)
+            PodmanClientTestCase.opener.assert_called_with(expected, encoding="utf-8")
 
     def test_connect_404(self):
         with mock.patch.multiple(Path, open=self.mocked_open, exists=MagicMock(return_value=True)):
@@ -110,7 +110,7 @@ class PodmanClientTestCase(unittest.TestCase):
 
             # Build path to support tests running as root or a user
             expected = Path(xdg.BaseDirectory.xdg_config_home) / "containers" / "containers.conf"
-            PodmanClientTestCase.opener.assert_called_with(expected)
+            PodmanClientTestCase.opener.assert_called_with(expected, encoding="utf-8")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change switches to using fstrings for url paths and addresses
additional new linting rules.

Newer pylint versions have some new rules which we're triggering

* inconsistent-return-statements (2.7)
* arguments-renamed (2.9)
* unspecified-encoding (2.10)
* use-list-literal (2.10)
* use-dict-literal (2.10)
* consider-using-f-string (2.11)

Disabled few options until the CI version is upgraded past 2.9

* duplicate-code
* bad-option-value