### PR TITLE
Allow passing string values to memory limits

### DIFF
--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -43,6 +43,40 @@ class ContainersIntegrationTest(base.IntegrationTest):
             for hosts_entry in formatted_hosts:
                 self.assertIn(hosts_entry, logs)
 
+    def _test_memory_limit(self, parameter_name, host_config_name):
+        """Base for tests which checks memory limits"""
+        memory_limit_tests = [
+            {'value': 1000, 'expected_value': 1000},
+            {'value': '1000', 'expected_value': 1000},
+            {'value': '1234b', 'expected_value': 1234},
+            {'value': '123k', 'expected_value': 123 * 1024},
+            {'value': '44m', 'expected_value': 44 * 1024 * 1024},
+            {'value': '2g', 'expected_value': 2 * 1024 * 1024 * 1024}
+        ]
+
+        for test in memory_limit_tests:
+            container = self.client.containers.create(
+                self.alpine_image, **{parameter_name: test['value']}
+            )
+            self.containers.append(container)
+            self.assertEqual(container.attrs.get('HostConfig', dict()).get(host_config_name), test['expected_value'])
+
+    def test_container_kernel_memory(self):
+        """Test passing kernel memory"""
+        self._test_memory_limit('kernel_memory', 'KernelMemory')
+
+    def test_container_mem_limit(self):
+        """Test passing memory limit"""
+        self._test_memory_limit('mem_limit', 'Memory')
+
+    def test_container_mem_reservation(self):
+        """Test passing memory reservation"""
+        self._test_memory_limit('mem_reservation', 'MemoryReservation')
+
+    def test_container_shm_size(self):
+        """Test passing shared memory size"""
+        self._test_memory_limit('shm_size', 'ShmSize')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

According to documentation in podman-py there is a possibility to pass e.g. for memory limit `100m` which means 100 mega bytes of memory limit.
[Unfortunately there is no such possibility in REST podman API.](https://docs.podman.io/en/latest/_static/api.html#operation/ContainerCreateLibpod)
What is more you can pass in such a form (`100m`) from podman cli.
Which means we are lacking such functionality in podman-py (hence the PR).

Test code : 

```
import podman
client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')

options = [
	{'kernel_memory': '20m'},
	{'kernel_memory': 300},
	{'mem_limit': 10000},
	{'mem_limit': '256m'},
	{'mem_reservation': 3000},
	{'mem_reservation': '3000k'},
	{'shm_size': 12345},
	{'shm_size': '1g'}
]

options_mapping = {
	'kernel_memory': 'KernelMemory',
	'mem_limit': 'Memory',
	'mem_reservation': 'MemoryReservation',
	'shm_size': 'ShmSize'
}

for option in options:
	try:
		c1 = client.containers.create(name='test', image='test_image', command=['/bin/sleep', '12345'], **option)
		print(f'Option {option} | real value {c1.attrs["HostConfig"][options_mapping[list(option.keys())[0]]]}')
		c1.remove()
	except podman.errors.exceptions.APIError as e:
		print(f'Failed {option} option with error {e}')
```

Before changes : 

```
Failed {'kernel_memory': '20m'} option with error 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal string into Go struct field LinuxMemory.resource_limits.memory.kernel of type int64)
Option {'kernel_memory': 300} | real value 300
Option {'mem_limit': 10000} | real value 10000
Failed {'mem_limit': '256m'} option with error 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal string into Go struct field LinuxMemory.resource_limits.memory.limit of type int64)
Option {'mem_reservation': 3000} | real value 3000
Failed {'mem_reservation': '3000k'} option with error 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal string into Go struct field LinuxMemory.resource_limits.memory.reservation of type int64)
Option {'shm_size': 12345} | real value 12345
Failed {'shm_size': '1g'} option with error 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal string into Go struct field SpecGenerator.shm_size of type int64)
```

After changes : 

```
Option {'kernel_memory': '20m'} | real value 20971520
Option {'kernel_memory': 300} | real value 300
Option {'mem_limit': 10000} | real value 10000
Option {'mem_limit': '256m'} | real value 268435456
Option {'mem_reservation': 3000} | real value 3000
Option {'mem_reservation': '3000k'} | real value 3072000
Option {'shm_size': 12345} | real value 12345
Option {'shm_size': '1g'} | real value 1073741824
```

Also ran the coverage with such results (which means tests were added and are passing since no failures): 
```
Ran 282 tests in 56.444s

FAILED (SKIP=3, errors=2)
```



