### PR TITLE
Support Python 3.10

### DIFF
--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -2,7 +2,12 @@ import io
 import random
 import tarfile
 import unittest
-from collections import Iterator
+try:
+    # Python >= 3.10
+    from collections.abc import Iterator
+except:
+    # Python < 3.10
+    from collections import Iterator
 
 import podman.tests.integration.base as base
 from podman import PodmanClient

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -49,17 +49,17 @@ class TestUtilsCase(unittest.TestCase):
     @patch.object(pathlib.Path, "exists", return_value=True)
     def test_containerignore_read(self, patch_exists):
         data = r"""# unittest
-        
+
         #Ignore the logs directory
         logs/
-        
+
         #Ignoring the password file
         passwords.txt
-        
+
         #Ignoring git and cache folders
         .git
         .cache
-        
+
         #Ignoring all the markdown and class files
         *.md
         **/*.class

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -65,7 +65,7 @@ class TestUtilsCase(unittest.TestCase):
         **/*.class
         """
 
-        with mock.patch("io.open", mock_open(read_data=data)):
+        with mock.patch("pathlib.Path.open", mock_open(read_data=data)):
             actual = api.prepare_containerignore(".")
 
         self.assertListEqual(
@@ -79,7 +79,7 @@ class TestUtilsCase(unittest.TestCase):
         """
 
         patch_exists.return_value = True
-        with mock.patch("io.open", mock_open(read_data=data)):
+        with mock.patch("pathlib.Path.open", mock_open(read_data=data)):
             actual = api.prepare_containerignore(".")
 
         self.assertListEqual(actual, [])

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -1,7 +1,12 @@
 import io
 import json
 import unittest
-from collections import Iterable
+try:
+    # Python >= 3.10
+    from collections.abc import Iterable
+except:
+    # Python < 3.10
+    from collections import Iterable
 from unittest.mock import patch
 
 import requests_mock

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -2,7 +2,12 @@ import base64
 import io
 import json
 import unittest
-from collections import Iterable
+try:
+    # Python >= 3.10
+    from collections.abc import Iterable
+except:
+    # Python < 3.10
+    from collections import Iterable
 
 import requests_mock
 

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -1,5 +1,10 @@
 import unittest
-from collections import Iterator
+try:
+    # Python >= 3.10
+    from collections.abc import Iterator
+except:
+    # Python < 3.10
+    from collections import Iterator
 from unittest.mock import patch, DEFAULT
 
 import requests_mock

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -1,6 +1,11 @@
 import types
 import unittest
-from collections import Iterable
+try:
+    # Python >= 3.10
+    from collections.abc import Iterable
+except:
+    # Python < 3.10
+    from collections import Iterable
 
 import requests_mock
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries :: Python Modules
 keywords = podman, libpod
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,6 @@
 black
 coverage
 fixtures~=3.0.0
-nose
+pytest
 pylint
 requests-mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py36,py38,py39,pylint,coverage
+envlist = py36,py38,py39,py310,pylint,coverage
 ignore_basepython_conflict = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ basepython = python3
 usedevelop = True
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
-commands = nosetests
+commands = pytest
 
 [testenv:venv]
 commands = {posargs}
@@ -19,7 +19,7 @@ commands = pylint podman
 
 [testenv:coverage]
 commands =
-    coverage run -m nose
+    coverage run -m pytest
     coverage report -m --skip-covered --fail-under=80 --omit=podman/tests/* --omit=.tox/*
 
 [testenv:black]


### PR DESCRIPTION
This PR adds support for Python 3.10. This required:

- Catering for the movement of Iterator and Iterable in the collections package in Python 3.10 (backwards compatibility with earlier Python versions is maintained)
- Migrating from Nose to PyTest for the test runner. Nose doesn't run under Python 3.10 and is unmaintained. PyTesthas really taken the community mindshare in recent years, and so this seems like a reasonable move. Two tests required modification for this. Those modifications were bug fixes.