### PR TITLE
Fix image build method to handle containerfile location correctly

### DIFF
--- a/podman/api/tar_utils.py
+++ b/podman/api/tar_utils.py
@@ -44,7 +44,7 @@ def prepare_containerfile(anchor: str, dockerfile: str) -> str:
     dockerfile_path = pathlib.Path(dockerfile)
 
     if dockerfile_path.parent.samefile(anchor_path):
-        return dockerfile
+        return dockerfile_path.name
 
     proxy_path = anchor_path / f".containerfile.{random.getrandbits(160):x}"
     shutil.copy2(dockerfile_path, proxy_path, follow_symlinks=False)

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -36,7 +36,7 @@ class BuildMixin:
             encoding (str) – The encoding for a stream. Set to gzip for compressing (ignored)
             pull (bool) – Downloads any updates to the FROM image in Dockerfile
             forcerm (bool) – Always remove intermediate containers, even after unsuccessful builds
-            dockerfile (str) – path within the build context to the Dockerfile
+            dockerfile (str) – full path to the Dockerfile / Containerfile
             buildargs (Mapping[str,str) – A dictionary of build arguments
             container_limits (Dict[str, Union[int,str]]) –
                 A dictionary of limits applied to each container created by the build process.

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -85,8 +85,9 @@ class BuildMixin:
                 shutil.copyfileobj(kwargs["fileobj"], file)
             body = api.create_tar(anchor=path.name, gzip=kwargs.get("gzip", False))
         elif "path" in kwargs:
+            filename = pathlib.Path(kwargs["path"]) / params["dockerfile"]
             # The Dockerfile will be copied into the context_dir if needed
-            params["dockerfile"] = api.prepare_containerfile(kwargs["path"], params["dockerfile"])
+            params["dockerfile"] = api.prepare_containerfile(kwargs["path"], str(filename))
 
             excludes = api.prepare_containerignore(kwargs["path"])
             body = api.create_tar(

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -86,9 +86,16 @@ class TestUtilsCase(unittest.TestCase):
         patch_exists.assert_called_once_with()
 
     @mock.patch("pathlib.Path.parent", autospec=True)
-    def test_containerfile(self, mock_parent):
+    def test_containerfile_1(self, mock_parent):
         mock_parent.samefile.return_value = True
         actual = api.prepare_containerfile("/work", "/work/Dockerfile")
+        self.assertEqual(actual, "Dockerfile")
+        mock_parent.samefile.assert_called()
+
+    @mock.patch("pathlib.Path.parent", autospec=True)
+    def test_containerfile_2(self, mock_parent):
+        mock_parent.samefile.return_value = True
+        actual = api.prepare_containerfile(".", "Dockerfile")
         self.assertEqual(actual, "Dockerfile")
         mock_parent.samefile.assert_called()
 

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -85,14 +85,12 @@ class TestUtilsCase(unittest.TestCase):
         self.assertListEqual(actual, [])
         patch_exists.assert_called_once_with()
 
-    @mock.patch("pathlib.Path", autospec=True)
-    def test_containerfile(self, mock_path):
-        mock_parent = mock_path.parent.return_value = Mock()
+    @mock.patch("pathlib.Path.parent", autospec=True)
+    def test_containerfile(self, mock_parent):
         mock_parent.samefile.return_value = True
-
         actual = api.prepare_containerfile("/work", "/work/Dockerfile")
-        self.assertEqual(actual, "/work/Dockerfile")
-        mock_path.assert_called()
+        self.assertEqual(actual, "Dockerfile")
+        mock_parent.samefile.assert_called()
 
     @mock.patch("shutil.copy2")
     def test_containerfile_copy(self, mock_copy):


### PR DESCRIPTION
The docstring for BuildMixin.build() specifies that the dockerfile
argument is relative to the path/build context.

BuildMixin.build() calls api.tar_utils.prepare_containerfile() whose
docstring specifies that the return value is relative to the context
directory.

This commit fixes a bug where the absolute path to the containerfile
was being returned from prepare_containerfile() causing the subsequent
image build to fail as the containerfile was not found at the erroneous
path.

This commit also fixes an incorrect test for the prepare_containerfile()
function.