### PR TITLE
Update CI to fail on Podman 4.0 errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,6 +61,7 @@ test_task:
 
     script:
         - ${SCRIPT_BASE}/enable_ssh.sh
+        - ${SCRIPT_BASE}/build_podman.sh
         - ${SCRIPT_BASE}/enable_podman.sh
         - ${SCRIPT_BASE}/test.sh
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,9 @@ ignore=CVS,docs
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=test_.*
+# ignore-patterns=test_.*
+
+ignore-paths=^podman/tests/.*$
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/contrib/cirrus/build_podman.sh
+++ b/contrib/cirrus/build_podman.sh
@@ -2,13 +2,9 @@
 
 set -xeo pipefail
 
-mkdir -p "$GOPATH/src/github.com/containers/"
-cd "$GOPATH/src/github.com/containers/"
+systemctl stop podman.socket || :
 
-systemctl stop podman.socket ||:
 dnf erase podman -y
-git clone https://github.com/containers/podman.git
+dnf copr enable rhcontainerbot/podman-next -y
+dnf install podman -y
 
-cd podman
-make binaries
-make install PREFIX=/usr

--- a/contrib/cirrus/test.sh
+++ b/contrib/cirrus/test.sh
@@ -2,6 +2,4 @@
 
 set -eo pipefail
 
-
-
 make tests

--- a/podman/api/tar_utils.py
+++ b/podman/api/tar_utils.py
@@ -84,7 +84,7 @@ def create_tar(
             return None
 
         # Workaround https://bugs.python.org/issue32713. Fixed in Python 3.7
-        if info.mtime < 0 or info.mtime > 8 ** 11 - 1:
+        if info.mtime < 0 or info.mtime > 8**11 - 1:
             info.mtime = int(info.mtime)
 
         # do not leak client information to service
@@ -97,9 +97,8 @@ def create_tar(
         return info
 
     if name is None:
-        name = tempfile.NamedTemporaryFile(
-            prefix="podman_context", suffix=".tar"
-        )  # pylint: disable=consider-using-with
+        # pylint: disable=consider-using-with
+        name = tempfile.NamedTemporaryFile(prefix="podman_context", suffix=".tar")
     else:
         name = pathlib.Path(name)
 

--- a/podman/api/typing_extensions.py
+++ b/podman/api/typing_extensions.py
@@ -884,7 +884,6 @@ elif _geqv_defined:
                 return collections.deque(*args, **kwds)
             return _generic_new(collections.deque, cls, *args, **kwds)
 
-
 else:
 
     class Deque(
@@ -911,7 +910,6 @@ elif hasattr(contextlib, 'AbstractContextManager'):
         extra=contextlib.AbstractContextManager,
     ):
         __slots__ = ()
-
 
 else:
 
@@ -994,7 +992,6 @@ elif _geqv_defined:
                 return collections.defaultdict(*args, **kwds)
             return _generic_new(collections.defaultdict, cls, *args, **kwds)
 
-
 else:
 
     class DefaultDict(
@@ -1031,7 +1028,6 @@ elif _geqv_defined:
             if _geqv(cls, OrderedDict):
                 return collections.OrderedDict(*args, **kwds)
             return _generic_new(collections.OrderedDict, cls, *args, **kwds)
-
 
 else:
 
@@ -1073,7 +1069,6 @@ elif (3, 5, 0) <= sys.version_info[:3] <= (3, 5, 1):
                 return collections.Counter(*args, **kwds)
             return _generic_new(collections.Counter, cls, *args, **kwds)
 
-
 elif _geqv_defined:
 
     class Counter(
@@ -1089,7 +1084,6 @@ elif _geqv_defined:
             if _geqv(cls, Counter):
                 return collections.Counter(*args, **kwds)
             return _generic_new(collections.Counter, cls, *args, **kwds)
-
 
 else:
 
@@ -1353,9 +1347,7 @@ elif HAVE_PROTOCOLS and not PEP_560:
                     bases = tuple(b for b in bases if b is not Generic)
                 namespace.update({'__origin__': origin, '__extra__': extra})
                 self = super(GenericMeta, cls).__new__(cls, name, bases, namespace, _root=True)
-                super(GenericMeta, self).__setattr__(
-                    '_gorg', self if not origin else _gorg(origin)
-                )
+                super(GenericMeta, self).__setattr__('_gorg', self if not origin else _gorg(origin))
                 self.__parameters__ = tvars
                 self.__args__ = (
                     tuple(
@@ -1479,9 +1471,7 @@ elif HAVE_PROTOCOLS and not PEP_560:
                 if not isinstance(params, tuple):
                     params = (params,)
                 if not params and _gorg(self) is not Tuple:
-                    raise TypeError(
-                        "Parameter list to %s[...] cannot be empty" % self.__qualname__
-                    )
+                    raise TypeError("Parameter list to %s[...] cannot be empty" % self.__qualname__)
                 msg = "Parameters to generic types must be types."
                 params = tuple(_type_check(p, msg) for p in params)
                 if self in (Generic, Protocol):
@@ -2108,7 +2098,6 @@ elif PEP_560:
             return hint
         return {k: _strip_annotations(t) for k, t in hint.items()}
 
-
 elif HAVE_ANNOTATED:
 
     def _is_dunder(name):
@@ -2343,7 +2332,6 @@ elif sys.version_info[:2] >= (3, 9):
         It's invalid when used anywhere except as in the example above.
         """
         raise TypeError("{} is not subscriptable".format(self))
-
 
 elif sys.version_info[:2] >= (3, 7):
 
@@ -2672,7 +2660,6 @@ elif sys.version_info[:2] >= (3, 9):
         """
         return _concatenate_getitem(self, parameters)
 
-
 elif sys.version_info[:2] >= (3, 7):
 
     class _ConcatenateForm(typing._SpecialForm, _root=True):
@@ -2820,7 +2807,6 @@ elif sys.version_info[:2] >= (3, 9):
         """
         item = typing._type_check(parameters, '{} accepts only single type.'.format(self))
         return _GenericAlias(self, (item,))
-
 
 elif sys.version_info[:2] >= (3, 7):
 

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -310,8 +310,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                     if search:
                         return int(search.group(1)) * (1024 ** mapping[search.group(2)])
                     raise TypeError(
-                        f"Passed string size {size} should be in format\\d+[bBkKmMgG] (e.g."
-                        " '100m')"
+                        f"Passed string size {size} should be in format\\d+[bBkKmMgG] (e.g. '100m')"
                     ) from bad_size
             else:
                 raise TypeError(
@@ -415,9 +414,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             if "Config" in args["log_config"]:
                 params["log_configuration"]["path"] = args["log_config"]["Config"].get("path")
                 params["log_configuration"]["size"] = args["log_config"]["Config"].get("size")
-                params["log_configuration"]["options"] = args["log_config"]["Config"].get(
-                    "options"
-                )
+                params["log_configuration"]["options"] = args["log_config"]["Config"].get("options")
             args.pop("log_config")
 
         for item in args.pop("mounts", []):

--- a/podman/domain/containers_manager.py
+++ b/podman/domain/containers_manager.py
@@ -25,10 +25,7 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         response = self.client.get(f"/containers/{key}/exists")
         return response.ok
 
-    # pylint is flagging 'container_id' here vs. 'key' parameter in super.get()
-    def get(
-        self, container_id: str
-    ) -> Container:  # pylint: disable=arguments-differ,arguments-renamed
+    def get(self, key: str) -> Container:
         """Get container by name or id.
 
         Args:
@@ -38,7 +35,7 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
             NotFound: when Container does not exist
             APIError: when an error return by service
         """
-        container_id = urllib.parse.quote_plus(container_id)
+        container_id = urllib.parse.quote_plus(key)
         response = self.client.get(f"/containers/{container_id}/json")
         response.raise_for_status()
         return self.prepare_model(attrs=response.json())

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -27,6 +27,7 @@ class ImagesManager(BuildMixin, Manager):
         return Image
 
     def exists(self, key: str) -> bool:
+        """Return true when image exists."""
         key = urllib.parse.quote_plus(key)
         response = self.client.get(f"/images/{key}/exists")
         return response.ok

--- a/podman/domain/pods.py
+++ b/podman/domain/pods.py
@@ -1,6 +1,6 @@
 """Model and Manager for Pod resources."""
 import logging
-from typing import Any, Dict, Tuple, Union, Optional
+from typing import Any, Dict, Optional, Tuple, Union
 
 from podman.domain.manager import PodmanResource
 
@@ -104,6 +104,8 @@ class Pod(PodmanResource):
         response = self.client.get(f"/pods/{self.id}/top", params=params)
         response.raise_for_status()
 
+        if len(response.text) == 0:
+            return {"Processes": [], "Titles": []}
         return response.json()
 
     def unpause(self) -> None:

--- a/podman/domain/pods_manager.py
+++ b/podman/domain/pods_manager.py
@@ -94,9 +94,7 @@ class PodsManager(Manager):
         Raises:
             APIError: when service reports error
         """
-        response = self.client.post(
-            "/pods/prune", params={"filters": api.prepare_filters(filters)}
-        )
+        response = self.client.post("/pods/prune", params={"filters": api.prepare_filters(filters)})
         response.raise_for_status()
 
         deleted: List[str] = []

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -3,5 +3,5 @@
 # Do not auto-update these from version.py,
 #   as test code should be changed to reflect changes in Podman API versions
 BASE_SOCK = "unix:///run/api.sock"
-LIBPOD_URL = "http://%2Frun%2Fapi.sock/v3.2.1/libpod"
+LIBPOD_URL = "http://%2Frun%2Fapi.sock/v4.0.0/libpod"
 COMPATIBLE_URL = "http://%2Frun%2Fapi.sock/v1.40"

--- a/podman/tests/integration/base.py
+++ b/podman/tests/integration/base.py
@@ -37,24 +37,22 @@ class IntegrationTest(fixtures.TestWithFixtures):
 
     @classmethod
     def setUpClass(cls) -> None:
+        super(fixtures.TestWithFixtures, cls).setUpClass()
+
         command = os.environ.get("PODMAN_BINARY", "podman")
         if shutil.which(command) is None:
             raise AssertionError(f"'{command}' not found.")
         IntegrationTest.podman = command
 
-        # For testing, lock in logging configuration
-        if "DEBUG" in os.environ:
-            logging.basicConfig(level=logging.DEBUG)
-        else:
-            logging.basicConfig(level=logging.INFO)
+        # This log_level is for our python code
+        log_level = os.environ.get("PODMAN_LOG_LEVEL", "INFO")
+        log_level = logging.getLevelName(log_level)
+        logging.basicConfig(level=log_level)
 
     def setUp(self):
         super().setUp()
 
-        # This is the log_level to pass to podman service
-        self.log_level = logging.WARNING
-        if "DEBUG" in os.environ:
-            self.log_level = logging.DEBUG
+        self.log_level = os.environ.get("PODMAN_LOG_LEVEL", "INFO")
 
         self.test_dir = self.useFixture(fixtures.TempDir()).path
         self.socket_file = os.path.join(self.test_dir, uuid.uuid4().hex)

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -67,10 +67,6 @@ class ContainersIntegrationTest(base.IntegrationTest):
                 test['expected_value'],
             )
 
-    def test_container_kernel_memory(self):
-        """Test passing kernel memory"""
-        self._test_memory_limit('kernel_memory', 'KernelMemory')
-
     def test_container_mem_limit(self):
         """Test passing memory limit"""
         self._test_memory_limit('mem_limit', 'Memory')

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -105,9 +105,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.assertIsInstance(logs_iter, Iterator)
 
             logs = list(logs_iter)
-            self.assertIn(random_string.encode("utf-8"), logs)
-            # podman 4.0 API support...
-            # self.assertIn((random_string + "\n").encode("utf-8"), logs)
+            self.assertIn((random_string + "\n").encode("utf-8"), logs)
 
         with self.subTest("Delete Container"):
             container.remove()

--- a/podman/tests/integration/utils.py
+++ b/podman/tests/integration/utils.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import subprocess
 import threading
+from contextlib import suppress
 from typing import List, Optional
 
 import time
@@ -36,7 +37,7 @@ class PodmanLauncher:
         podman_path: Optional[str] = None,
         timeout: int = 0,
         privileged: bool = False,
-        log_level: int = logging.WARNING,
+        log_level: str = "WARNING",
     ) -> None:
         """create a launcher and build podman command"""
         podman_exe: str = podman_path
@@ -57,7 +58,10 @@ class PodmanLauncher:
 
         self.cmd.append(podman_exe)
 
-        self.cmd.append(f"--log-level={logging.getLevelName(log_level).lower()}")
+        logger.setLevel(logging.getLevelName(log_level))
+
+        # Map from python to go logging levels, FYI trace level breaks cirrus logging
+        self.cmd.append(f"--log-level={log_level.lower()}")
 
         if os.environ.get("container") == "oci":
             self.cmd.append("--storage-driver=vfs")
@@ -120,5 +124,8 @@ class PodmanLauncher:
             self.proc.kill()
             return_code = self.proc.wait()
         self.proc = None
+
+        with suppress(FileNotFoundError):
+            os.remove(self.socket_file)
 
         logger.info("Command return Code: %d refid=%s", return_code, self.reference_id)

--- a/podman/tests/unit/test_config.py
+++ b/podman/tests/unit/test_config.py
@@ -47,9 +47,7 @@ class PodmanConfigTestCase(unittest.TestCase):
 
             expected = urllib.parse.urlparse("ssh://qe@localhost:2222/run/podman/podman.sock")
             self.assertEqual(config.active_service.url, expected)
-            self.assertEqual(
-                config.services["production"].identity, Path("/home/root/.ssh/id_rsa")
-            )
+            self.assertEqual(config.services["production"].identity, Path("/home/root/.ssh/id_rsa"))
 
             PodmanConfigTestCase.opener.assert_called_with(
                 Path("/home/developer/containers.conf"), encoding='utf-8'

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -242,9 +242,7 @@ class ContainersManagerTestCase(unittest.TestCase):
             json=FIRST_CONTAINER,
         )
 
-        with patch.multiple(
-            Container, logs=DEFAULT, wait=DEFAULT, autospec=True
-        ) as mock_container:
+        with patch.multiple(Container, logs=DEFAULT, wait=DEFAULT, autospec=True) as mock_container:
             mock_container["logs"].return_value = []
             mock_container["wait"].return_value = {"StatusCode": 0}
 
@@ -277,9 +275,7 @@ class ContainersManagerTestCase(unittest.TestCase):
             b"This is a unittest - line 2",
         )
 
-        with patch.multiple(
-            Container, logs=DEFAULT, wait=DEFAULT, autospec=True
-        ) as mock_container:
+        with patch.multiple(Container, logs=DEFAULT, wait=DEFAULT, autospec=True) as mock_container:
             mock_container["wait"].return_value = {"StatusCode": 0}
 
             with self.subTest("Results not streamed"):

--- a/podman/tests/unit/test_manifests.py
+++ b/podman/tests/unit/test_manifests.py
@@ -1,7 +1,7 @@
 import unittest
 
 from podman import PodmanClient, tests
-from podman.domain.manifests import ManifestsManager, Manifest
+from podman.domain.manifests import Manifest, ManifestsManager
 
 
 class ManifestTestCase(unittest.TestCase):
@@ -9,11 +9,7 @@ class ManifestTestCase(unittest.TestCase):
         super().setUp()
 
         self.client = PodmanClient(base_url=tests.BASE_SOCK)
-
-    def tearDown(self) -> None:
-        super().tearDown()
-
-        self.client.close()
+        self.addCleanup(self.client.close)
 
     def test_podmanclient(self):
         manager = self.client.manifests
@@ -24,13 +20,8 @@ class ManifestTestCase(unittest.TestCase):
             self.client.manifests.list()
 
     def test_name(self):
-        with self.assertRaises(ValueError):
-            manifest = Manifest(attrs={"names": ""})
-            _ = manifest.name
-
-        with self.assertRaises(ValueError):
-            manifest = Manifest()
-            _ = manifest.name
+        manifest = Manifest()
+        self.assertIsNone(manifest.name)
 
 
 if __name__ == '__main__':

--- a/podman/tests/unit/test_volumesmanager.py
+++ b/podman/tests/unit/test_volumesmanager.py
@@ -38,11 +38,7 @@ class VolumesManagerTestCase(unittest.TestCase):
         super().setUp()
 
         self.client = PodmanClient(base_url=tests.BASE_SOCK)
-
-    def tearDown(self) -> None:
-        super().tearDown()
-
-        self.client.close()
+        self.addCleanup(self.client.close)
 
     def test_podmanclient(self):
         manager = self.client.volumes

--- a/podman/version.py
+++ b/podman/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "3.2.1"
+__version__ = "4.0.0"
 __compatible_version__ = "1.40"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,20 @@ exclude = '''
 profile = "black"
 line_length = 100
 [build-system]
+# Any changes should be copied into requirements.txt, setup.cfg, and/or test-requirements.txt
 requires = [
+    "pyxdg>=0.26",
     "requests>=2.24",
+    "setuptools>=46.4",
+    "sphinx",
     "toml>=0.10.2",
     "urllib3>=1.24.2",
-    "pyxdg>=0.26",
-    "setuptools>=46.4",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+# Any changes should be copied into pyproject.toml
+pyxdg>=0.26
 requests>=2.24
+setuptools
+sphinx
 toml>=0.10.2
 urllib3>=1.24.2
-pyxdg>=0.26
-sphinx
 wheel
-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,12 @@ keywords = podman, libpod
 include_package_data = True
 python_requires = >=3.6
 test_suite =
+# Any changes should be copied into pyproject.toml
 install_requires =
+    pyxdg>=0.26
     requests>=2.24
     toml>=0.10.2
     urllib3>=1.24.2
-    pyxdg>=0.26
 
 # typing_extensions are included for RHEL 8.5
 # typing_extensions;python_version<'3.8'

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,10 @@
-import setuptools
-
 import fnmatch
+
+import setuptools
 from setuptools import find_packages
 from setuptools.command.build_py import build_py as build_py_orig
 
 excluded = [
-    "podman/api_connection.py",
-    "podman/containers/*",
-    "podman/images/*",
-    "podman/manifests/*",
-    "podman/networks/*",
-    "podman/pods/*",
-    "podman/system/*",
-    "podman/system/*",
     "podman/tests/*",
 ]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,9 @@
+# Any changes should be copied into pyproject.toml
 -r requirements.txt
 black
 coverage
 fixtures~=3.0.0
-pytest
 pylint
+pytest
 requests-mock
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py36,py38,py39,py310,pylint,coverage
+envlist = pylint,coverage,py36,py38,py39,py310
 ignore_basepython_conflict = true
 
 [testenv]
@@ -8,7 +8,11 @@ basepython = python3
 usedevelop = True
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
-commands = pytest
+commands = pytest {posargs}
+setenv =
+    PODMAN_LOG_LEVEL = {env:PODMAN_LOG_LEVEL:INFO}
+    PODMAN_BINARY = {env:PODMAN_BINARY:podman}
+    DEBUG = {env:DEBUG:0}
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
CI has been testing against containers/podman/main to report issues.
With the release of Podman 4.0, any errors are now failures.

* Makefile target "test" and "lint" updated to use tox covering
  python 3.6, 3.8, 3.9 and 3.10.
* Added black formatting check to Makefile target "lint"
* Source code changes made to satisfy "tox -e black-format" and
  "tox -e pylint"

Signed-off-by: Jhon Honce <jhonce@redhat.com>