### PR TITLE
Cirrus: Use dedicated VM image for automation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,15 +19,8 @@ env:
     UBUNTU_NAME: "ubuntu-2110"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c4560539387953152"
-    FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-
-    # Container FQIN's
-    FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
+    IMAGE_SUFFIX: "c4764556961513472"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-podman-py-${IMAGE_SUFFIX}"
 
 
 gcp_credentials: ENCRYPTED[0c639039cdd3a9a93fac7746ea1bf366d432e5ff3303bf293e64a7ff38dee85fd445f71625fa5626dc438be2b8efe939]
@@ -42,34 +35,6 @@ gce_instance:
     disk: 200  # Required for performance reasons
     image_name: "${FEDORA_CACHE_IMAGE_NAME}"
 
-
-# This task is critical.  It updates the "last-used by" timestamp stored
-# in metadata for all VM images.  This mechanism functions in tandem with
-# an out-of-band pruning operation to remove disused VM images.
-meta_task:
-    alias: meta
-    name: "VM img. keepalive"
-
-    container: &smallcontainer
-        image: "quay.io/libpod/imgts:$IMAGE_SUFFIX"
-        cpu: 1
-        memory: 1
-
-    env:
-        IMGNAMES: >-
-            ${FEDORA_CACHE_IMAGE_NAME}
-            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-            ${UBUNTU_CACHE_IMAGE_NAME}
-        BUILDID: "${CIRRUS_BUILD_ID}"
-        REPOREF: "${CIRRUS_REPO_NAME}"
-        GCPJSON: ENCRYPTED[e8a53772eff6e86bf6b99107b6e6ee3216e2ca00c36252ae3bd8cb29d9b903ffb2e1a1322ea810ca251b04f833b8f8d9]
-        GCPNAME: ENCRYPTED[fb878daf188d35c2ed356dc777267d99b59863ff3abf0c41199d562fca50ba0668fdb0d87e109c9eaa2a635d2825feed]
-        GCPPROJECT: "libpod-218412"
-
-    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
-    script: /usr/local/bin/entrypoint.sh
-
-
 gating_task:
     name: "Gating test"
     alias: gating
@@ -77,12 +42,6 @@ gating_task:
     # Only run this on PRs, never during post-merge testing.  This is also required
     # for proper setting of EPOCH_TEST_COMMIT value, required by validation tools.
     only_if: $CIRRUS_PR != ""
-
-    # Runs within Cirrus's "community cluster"
-    container:
-        image: "$FEDORA_CONTAINER_FQIN"
-        cpu: 4
-        memory: 12
 
     timeout_in: 20m
 
@@ -122,6 +81,29 @@ latest_task:
         - ${SCRIPT_BASE}/enable_podman.sh
         - ${SCRIPT_BASE}/test.sh
 
+# This task is critical.  It updates the "last-used by" timestamp stored
+# in metadata for all VM images.  This mechanism functions in tandem with
+# an out-of-band pruning operation to remove disused VM images.
+meta_task:
+    alias: meta
+    name: "VM img. keepalive"
+
+    container: &smallcontainer
+        image: "quay.io/libpod/imgts:$IMAGE_SUFFIX"
+        cpu: 1
+        memory: 1
+
+    env:
+        IMGNAMES: ${FEDORA_CACHE_IMAGE_NAME}
+        BUILDID: "${CIRRUS_BUILD_ID}"
+        REPOREF: "${CIRRUS_REPO_NAME}"
+        GCPJSON: ENCRYPTED[e8a53772eff6e86bf6b99107b6e6ee3216e2ca00c36252ae3bd8cb29d9b903ffb2e1a1322ea810ca251b04f833b8f8d9]
+        GCPNAME: ENCRYPTED[fb878daf188d35c2ed356dc777267d99b59863ff3abf0c41199d562fca50ba0668fdb0d87e109c9eaa2a635d2825feed]
+        GCPPROJECT: "libpod-218412"
+
+    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
+    script: /usr/local/bin/entrypoint.sh
+
 # Status aggregator for all tests.  This task simply ensures a defined
 # set of tasks all passed, and allows confirming that based on the status
 # of this task.
@@ -135,6 +117,11 @@ success_task:
         - gating
         - test
         - latest
-    container: *smallcontainer
+    container:
+        image: quay.io/libpod/alpine:latest
+        cpu: 1
+        memory: 1
+    env:
+        CIRRUS_SHELL: "/bin/sh"
     clone_script: *noop
     script: *noop


### PR DESCRIPTION
Previously the VM images used for automation were
generic/one-size-fits-all.  However over time, various repos. have
required numerous updates resulting in a great deal of bloat.  To combat
this, a dedicated VM image has been crafted for use just by this repo.
Put this into use, and re-order tasks in `.cirrus.yml` to match more
closely with the order of operations.

Ref: https://github.com/containers/automation_images/pull/111

Signed-off-by: Chris Evich <cevich@redhat.com>