### PR TITLE
Fix stream option for container logs

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -250,6 +250,7 @@ class Container(PodmanResource):
             until (Union[datetime, int]): Show logs that occurred before the given
                 datetime or integer epoch (in seconds)
         """
+        stream = bool(kwargs.get("stream", False))
         params = {
             "follow": kwargs.get("follow", kwargs.get("stream", None)),
             "since": api.prepare_timestamp(kwargs.get("since")),
@@ -260,10 +261,10 @@ class Container(PodmanResource):
             "until": api.prepare_timestamp(kwargs.get("until")),
         }
 
-        response = self.client.get(f"/containers/{self.id}/logs", params=params)
+        response = self.client.get(f"/containers/{self.id}/logs", stream=stream, params=params)
         response.raise_for_status()
 
-        if bool(kwargs.get("stream", False)):
+        if stream:
             return api.stream_frames(response)
         return api.frames(response)
 


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

Logs' stream option is not working correctly right now. If it's set to `stream=True` and `follow=True` it does not return any logs from container.

Before my changes : 
```
>>> import podman
>>> import datetime
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> container = client.containers.create(image='465a95569b4a', entrypoint=['/bin/bash', '-c'], command=['sleep 2;echo 123;sleep 2;echo 456;sleep 2'])
        print(f'[{datetime.datetime.now()}] {log}')>>> container.start()
>>> for log in container.logs(stream=True, follow=True):
...     print(f'[{datetime.datetime.now()}] {log}')
...
>>> container.remove()
>>>
```

and after changes : 
```
>>> import podman
>>> import datetime
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> container = client.containers.create(image='465a95569b4a', entrypoint=['/bin/bash', '-c'], command=['sleep 2;echo 123;sleep 2;echo 456;sleep 2'])
>>> container.start()
>>> for log in container.logs(stream=True, follow=True):
...     print(f'[{datetime.datetime.now()}] {log}')
...
[2022-03-03 11:46:25.489805] b'123'
[2022-03-03 11:46:27.495115] b'456'
>>> container.remove()
>>>
```

Note : I've run tests prior and after making changes, and they remained the same. I can't fix the bugged/failing ones as I'm working on podman 3.2.3 (official RHEL podman release) but the API is now in 4.0.0 form which implies that it is compatible with podman 4.0.0 which is unavailable as for now, therefore I'm skipping posting tests, I'll post only exemplary code.