### PR TITLE
Add missing to_bytes for memswap_limit

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -492,7 +492,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             "kernelTCP": args.pop("kernel_memory_tcp", None),
             "limit": to_bytes(args.pop("mem_limit", None)),
             "reservation": to_bytes(args.pop("mem_reservation", None)),
-            "swap": args.pop("memswap_limit", None),
+            "swap": to_bytes(args.pop("memswap_limit", None)),
             "swappiness": args.pop("mem_swappiness", None),
             "useHierarchy": args.pop("mem_use_hierarchy", None),
         }

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -46,7 +46,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             for hosts_entry in formatted_hosts:
                 self.assertIn(hosts_entry, logs)
 
-    def _test_memory_limit(self, parameter_name, host_config_name):
+    def _test_memory_limit(self, parameter_name, host_config_name, set_mem_limit=False):
         """Base for tests which checks memory limits"""
         memory_limit_tests = [
             {'value': 1000, 'expected_value': 1000},
@@ -58,8 +58,13 @@ class ContainersIntegrationTest(base.IntegrationTest):
         ]
 
         for test in memory_limit_tests:
+            if set_mem_limit:
+                parameters = {parameter_name: test['value'], 'mem_limit': test['expected_value'] - 100}
+            else:
+                parameters = {parameter_name: test['value']}
+
             container = self.client.containers.create(
-                self.alpine_image, **{parameter_name: test['value']}
+                self.alpine_image, **parameters
             )
             self.containers.append(container)
             self.assertEqual(
@@ -70,6 +75,10 @@ class ContainersIntegrationTest(base.IntegrationTest):
     def test_container_mem_limit(self):
         """Test passing memory limit"""
         self._test_memory_limit('mem_limit', 'Memory')
+
+    def test_container_memswap_limit(self):
+        """Test passing memory swap limit"""
+        self._test_memory_limit('memswap_limit', 'MemorySwap', set_mem_limit=True)
 
     def test_container_mem_reservation(self):
         """Test passing memory reservation"""

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -62,9 +62,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             if set_mem_limit:
                 parameters['mem_limit'] = test['expected_value'] - 100
 
-            container = self.client.containers.create(
-                self.alpine_image, **parameters
-            )
+            container = self.client.containers.create(self.alpine_image, **parameters)
             self.containers.append(container)
             self.assertEqual(
                 container.attrs.get('HostConfig', dict()).get(host_config_name),

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -58,10 +58,9 @@ class ContainersIntegrationTest(base.IntegrationTest):
         ]
 
         for test in memory_limit_tests:
+            parameters = {parameter_name: test['value']}
             if set_mem_limit:
-                parameters = {parameter_name: test['value'], 'mem_limit': test['expected_value'] - 100}
-            else:
-                parameters = {parameter_name: test['value']}
+                parameters['mem_limit'] = test['expected_value'] - 100
 
             container = self.client.containers.create(
                 self.alpine_image, **parameters


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

It turned out I've forgotten to add `to_bytes()` to `memswap_limit` (which was done in #150).
So as a hotfix I've created another PR to fix it, along with test addition.

As a tradition, before the changes : 

```
4 failed, 161 passed, 3 skipped, 1 error in 90.22s
>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> container = client.containers.create(image='465a95569b4a', memswap_limit='1m')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/podman/domain/containers_create.py", line 225, in create
    response.raise_for_status(not_found=ImageNotFound)
  File "/usr/lib/python3.6/site-packages/podman/api/client.py", line 65, in raise_for_status
    raise APIError(cause, response=self._response, explanation=message)
podman.errors.exceptions.APIError: 500 Server Error: Internal Server Error (Decode(): json: cannot unmarshal string into Go struct field LinuxMemory.resource_limits.memory.swap of type int64)
```

and after changes : 
```
4 failed, 162 passed, 3 skipped, 1 error in 90.81s
>>> import podman
>>> client = podman.PodmanClient(base_url='unix:///run/podman/podman.sock')
>>> container = client.containers.create(image='465a95569b4a', memswap_limit='1m')
>>> container.attrs['HostConfig']['MemorySwap']
1048576
```