### PR TITLE
Fix container commit()

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -92,7 +92,7 @@ class Container(PodmanResource):
         Keyword Args:
             author (str): Name of commit author
             changes (List[str]): Instructions to apply during commit
-            comment (List[str]): Instructions to apply while committing in Dockerfile format
+            comment (str): Commit message to include with Image, overrides keyword message
             conf (dict[str, Any]): Ignored.
             format (str): Format of the image manifest and metadata
             message (str): Commit message to include with Image
@@ -101,7 +101,7 @@ class Container(PodmanResource):
         params = {
             "author": kwargs.get("author"),
             "changes": kwargs.get("changes"),
-            "comment": kwargs.get("comment"),
+            "comment": kwargs.get("comment", kwargs.get("message")),
             "container": self.id,
             "format": kwargs.get("format"),
             "pause": kwargs.get("pause"),
@@ -112,7 +112,7 @@ class Container(PodmanResource):
         response.raise_for_status()
 
         body = response.json()
-        return ImagesManager(client=self.client).get(body["ID"])
+        return ImagesManager(client=self.client).get(body["Id"])
 
     def diff(self) -> List[Dict[str, int]]:
         """Report changes of a container's filesystem.

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -146,6 +146,17 @@ class ContainersIntegrationTest(base.IntegrationTest):
             with self.assertRaises(NotFound):
                 self.client.containers.get(top_ctnr.id)
 
+    def test_container_commit(self):
+        """Commit new image."""
+        busybox = self.client.images.pull("quay.io/libpod/busybox", tag="latest")
+        container = self.client.containers.create(
+            busybox, command=["echo", f"{random.getrandbits(160):x}"]
+        )
+
+        image = container.commit(repository="busybox.local", tag="unittest")
+        self.assertIn("localhost/busybox.local:unittest", image.attrs["RepoTags"])
+        busybox.remove(force=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -306,7 +306,7 @@ class ContainersTestCase(unittest.TestCase):
             "&container=87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd&format=docker"
             "&pause=True&repo=quay.local&tag=unittest",
             status_code=201,
-            json={"ID": "d2459aad75354ddc9b5b23f863786e279637125af6ba4d4a83f881866b3c903f"},
+            json={"Id": "d2459aad75354ddc9b5b23f863786e279637125af6ba4d4a83f881866b3c903f"},
         )
         get_adapter = mock.get(
             tests.LIBPOD_URL


### PR DESCRIPTION
Use correct key when retrieving the resulting image after using
container commit to create said image.

* Update unittests to correct mocked results
* Add integration test for container commit()

Fixes #166

Signed-off-by: Jhon Honce <jhonce@redhat.com>