### PR TITLE
Allow pushing images with tag different than latest

### DIFF
--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -208,7 +208,8 @@ class ImagesManager(BuildMixin, Manager):
             "tlsVerify": kwargs.get("tlsVerify"),
         }
 
-        name = urllib.parse.quote_plus(repository)
+        name = f'{repository}:{tag}' if tag else repository
+        name = urllib.parse.quote_plus(name)
         response = self.client.post(f"/images/{name}/push", params=params, headers=headers)
         response.raise_for_status(not_found=ImageNotFound)
 

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -43,7 +43,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             proper_container.start()
             proper_container.wait()
             logs = b"\n".join(proper_container.logs()).decode()
-            formatted_hosts = [f"{ip} {hosts}" for hosts, ip in extra_hosts.items()]
+            formatted_hosts = [f"{ip}\t{hosts}" for hosts, ip in extra_hosts.items()]
             for hosts_entry in formatted_hosts:
                 self.assertIn(hosts_entry, logs)
 

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -417,7 +417,7 @@ class ImagesManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_push(self, mock):
-        mock.post(tests.LIBPOD_URL + "/images/quay.io%2ffedora/push")
+        mock.post(tests.LIBPOD_URL + "/images/quay.io%2Ffedora%3Alatest/push")
 
         report = self.client.images.push("quay.io/fedora", "latest")
 


### PR DESCRIPTION
I've made this PR because it looks like that `tag` parameter was skipped when pushing image to registry.

Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>