### PR TITLE
containers.list() has a different labels attribute

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -43,6 +43,8 @@ class Container(PodmanResource):
     def labels(self):
         """dict[str, str]: Returns labels associated with container."""
         with suppress(KeyError):
+            if "Labels" in self.attrs:
+                return self.attrs["Labels"]
             return self.attrs["Config"]["Labels"]
         return {}
 


### PR DESCRIPTION
https://docs.podman.io/en/latest/_static/api.html#operation/ContainerListLibpod returns the container labels in the `["Labels"]` attribute instead of `["Config"]["Labels"]`