### PR TITLE
CoPR: fix CentOS 8 Stream build

### DIFF
--- a/python-podman.spec.rpkg
+++ b/python-podman.spec.rpkg
@@ -59,7 +59,7 @@ Requires: python%{python3_pkgversion}-requests
 %else
 BuildRequires: pyproject-rpm-macros
 %endif
-%if 0%{?fedora} <= 35
+%if 0%{?fedora} <= 35 && ! 0%{?rhel}
 BuildRequires: python%{python3_pkgversion}-toml
 Requires: python%{python3_pkgversion}-toml
 %endif


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

c8s fails without this change: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4537996/

c8s successful with this change: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4538017/ 


@rhatdan @jwhonce PTAL.