### PR TITLE
Fix TypeError in container's wait method

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -65,9 +65,11 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             dns_search (List[str]): DNS search domains.
             domainname (Union[str, List[str]]): Set custom DNS search domains.
             entrypoint (Union[str, List[str]]): The entrypoint for the container.
-            environment (Union[Dict[str, str], List[str]): Environment variables to set inside
-                the container, as a dictionary or a List[str] in the format
-                ["SOMEVARIABLE=xxx", "SOMEOTHERVARIABLE=xyz"].
+            environment (Dict[str, str]): Environment variables to set inside
+                the container, as a dictionary.
+
+                For example: {"SOMEVARIABLE"="xxx", "SOMEOTHERVARIABLE"="xyz"}
+
             extra_hosts (Dict[str, str]): Additional hostnames to resolve inside the container,
                 as a mapping of hostname to IP address.
             group_add (List[str]): List of additional group names and/or IDs that the container

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -77,7 +77,7 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         if log_type in ("json-file", "journald"):
             log_iter = container.logs(stdout=stdout, stderr=stderr, stream=True, follow=True)
 
-        exit_status = container.wait()["StatusCode"]
+        exit_status = container.wait()
         if exit_status != 0:
             log_iter = None
             if not kwargs.get("auto_remove", False):


### PR DESCRIPTION
For the doc change: list of string does not work with `environment` argument

Fixes No.3 in #184, `.wait()` returns an integer not a dictionary