### PR TITLE
adding pass-through layers, output and outputformat to building images.

### DIFF
--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -165,9 +165,9 @@ class BuildMixin:
             "squash": kwargs.get("squash"),
             "t": kwargs.get("tag"),
             "target": kwargs.get("target"),
-            'layers': kwargs.get("layers"),
-            'output': kwargs.get("output"),
-            'outputformat': kwargs.get("outputformat"),
+            "layers": kwargs.get("layers"),
+            "output": kwargs.get("output"),
+            "outputformat": kwargs.get("outputformat"),
         }
 
         if "buildargs" in kwargs:

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -61,6 +61,9 @@ class BuildMixin:
             isolation (str) – Isolation technology used during build. (ignored)
             use_config_proxy (bool) – (ignored)
             http_proxy (bool) - Inject http proxy environment variables into container (Podman only)
+            layers (bool) - Cache intermediate layers during build.
+            output (str) - specifies if any custom build output is selected for following build.
+            outputformat (str) - The format of the output image's manifest and configuration data.
 
         Returns:
             first item is the podman.domain.images.Image built
@@ -162,6 +165,9 @@ class BuildMixin:
             "squash": kwargs.get("squash"),
             "t": kwargs.get("tag"),
             "target": kwargs.get("target"),
+            'layers': kwargs.get("layers"),
+            'output': kwargs.get("output"),
+            'outputformat': kwargs.get("outputformat"),
         }
 
         if "buildargs" in kwargs:


### PR DESCRIPTION
While working to replicate local podman image build commands in python, the 3 options, layers, output and outputformat were removed from kwargs in images.build.  These options are now passthrough to the REST API and replicated the caching that is done with the command line.  I extracted these options from the REST call made below and once added as pass-through, allowed caching to work.  Note, I am new to this so feedback would be great.  I could hardly find the output and outputformat options in any documentation except for buildah build under podman.

```
podman build -f /.../test_pdw_dockerfile.ubuntu2004 -t "pershey/test_pdw_dockerfile.ubuntu2004:latest"
```

Signed-off-by: Eric Pershey <pershey@anl.gov>