### PR TITLE
update urllib to 1.26.5 for a CVE found in previous versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     "setuptools>=46.4",
     "sphinx",
     "toml>=0.10.2",
-    "urllib3>=1.24.2",
+    "urllib3>=1.26.5",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests>=2.24
 setuptools
 sphinx
 toml>=0.10.2
-urllib3>=1.24.2
+urllib3>=1.26.5
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pyxdg>=0.26
     requests>=2.24
     toml>=0.10.2
-    urllib3>=1.24.2
+    urllib3>=1.26.5
 
 # typing_extensions are included for RHEL 8.5
 # typing_extensions;python_version<'3.8'


### PR DESCRIPTION
resolves https://github.com/advisories/GHSA-wqvq-5m8c-6g24
https://issues.redhat.com/browse/OCPBUGS-1926

Signed-off-by: Charlie Doern <cdoern@redhat.com>