### PR TITLE
Correct path for rtd conf.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,6 @@ python:
     - requirements: requirements.txt
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true
 


### PR DESCRIPTION
Signed-off-by: Brent Baude <bbaude@redhat.com>