### PR TITLE
Clean up pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -305,13 +305,6 @@ max-line-length=100
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no
@@ -329,7 +322,6 @@ single-line-if-stmt=no
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style.
 argument-rgx=[a-z_][a-z0-9_]{1,30}$
-argument-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case
@@ -436,7 +428,6 @@ property-classes=abc.abstractproperty
 # Regular expression matching correct variable names. Overrides variable-
 # naming-style.
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 [SIMILARITIES]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/containers/podman-py
 license =  Apache-2.0
-license_file =  LICENSE
+license_files =  LICENSE
 platforms = any
 project_urls =
     Bug Tracker = https://github.com/containers/podman-py/issues
@@ -34,10 +34,10 @@ python_requires = >=3.6
 test_suite =
 # Any changes should be copied into pyproject.toml
 install_requires =
-    pyxdg>=0.26
-    requests>=2.24
-    toml>=0.10.2
-    urllib3>=1.26.5
+    pyxdg >=0.26
+    requests >=2.24
+    toml >=0.10.2
+    urllib3 >=1.26.5
 
 # typing_extensions are included for RHEL 8.5
 # typing_extensions;python_version<'3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ setenv =
 commands = {posargs}
 
 [testenv:pylint]
+depends = py310
+basepython = python3.10
 allowlist_externals = pylint
 commands = pylint podman
 


### PR DESCRIPTION
* Removed configuration items from .pylintrc that are no longer supported and generating warnings.
* Locked "pylint" tox environment to python 3.10. Python 3.11 is not supported by Pylint 2.15.5. Dill dependency needs to be updated.

Signed-off-by: Jhon Honce <jhonce@redhat.com>