### PR TITLE
Added port binding range

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -173,12 +173,18 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
 
                     For example: {'9090': 7878, '10932/tcp': '8781',
                                   "8989/tcp": ("127.0.0.1", 9091)}
-                - A dictionary of the options above except for random host port.
-                  The dictionary has additional option - "range" which allows binding range of ports.
+                - A dictionary of the options mentioned above except for random host port.
+                  The dictionary has additional option "range",
+                    which allows binding range of ports.
+
                     For example:
                         - {'2222/tcp': {"port": 3333, "range": 4}}
                         - {'1111/tcp': {"port": ('127.0.0.1', 1111), "range": 4}}
-                        - {'1111/tcp': [{"port": 1234, "range": 4}, {"ip": "127.0.0.1", "port": 4567}]}
+                        - {'1111/tcp': [
+                              {"port": 1234, "range": 4},
+                              {"ip": "127.0.0.1", "port": 4567}
+                            ]
+                          }
 
             privileged (bool): Give extended privileges to this container.
             publish_all_ports (bool): Publish all ports to the host.

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -150,8 +150,8 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             platform (str): Platform in the format os[/arch[/variant]]. Only used if the method
                 needs to pull the requested image.
             ports (Dict[str, Union[int, Tuple[str, int], List[int],
-                      Dict[str, Union[int, Tuple[str, int], List[int]]]]]): Ports to bind inside
-                the container.
+                                   Dict[str, Union[int, Tuple[str, int], List[int]]]]]
+                  ): Ports to bind inside the container.
 
                 The keys of the dictionary are the ports to bind inside the container, either as an
                 integer or a string in the form port/protocol, where the protocol is either


### PR DESCRIPTION
Signed-off-by: Jankowiak Szymon-PRFJ46 <szymon.jankowiak@motorolasolutions.com>

Added support for `range` in `ports`.
The range is available at REST API but was not supported in podman-py.
I've tried to keep the backward compatibility (hopefully it works, previously written test case works at the very least).
Unfortunately it was impossible to add `range` without adding new syntax for ports (using dictionary instead of None or int or tuple or list).
The newly added syntax should work in the same manner as the previously used one, but with addition of `range` keyword.