### PR TITLE
Fix the ability to run containers

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -530,7 +530,8 @@ class Container(PodmanResource):
             params["interval"] = interval
 
         # This API endpoint responds with a JSON encoded integer.
-        # See: https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerWaitLibpod
+        # See:
+        # https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerWaitLibpod
         response = self.client.post(f"/containers/{self.id}/wait", params=params)
         response.raise_for_status()
         return response.json()

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -10,7 +10,6 @@ import requests
 from requests import Response
 
 from podman import api
-from podman.api import Literal
 from podman.domain.images import Image
 from podman.domain.images_manager import ImagesManager
 from podman.domain.manager import PodmanResource

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -501,7 +501,7 @@ class Container(PodmanResource):
         """
         raise NotImplementedError("Container.update() is not supported by Podman service.")
 
-    def wait(self, **kwargs) -> Dict[Literal["StatusCode", "Error"], Any]:
+    def wait(self, **kwargs) -> int:
         """Block until the container enters given state.
 
         Keyword Args:
@@ -529,6 +529,9 @@ class Container(PodmanResource):
             params["condition"] = condition
         if interval != "":
             params["interval"] = interval
+
+        # This API endpoint responds with a JSON encoded integer.
+        # See: https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerWaitLibpod
         response = self.client.post(f"/containers/{self.id}/wait", params=params)
         response.raise_for_status()
         return response.json()

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -240,6 +240,9 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             volumes_from (List[str]): List of container names or IDs to get volumes from.
             working_dir (str): Path to the working directory.
 
+        Returns:
+            A Container object.
+
         Raises:
             ImageNotFound: when Image not found by Podman service
             APIError: when Podman service reports an error

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -257,8 +257,9 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
         )
         response.raise_for_status(not_found=ImageNotFound)
 
-        body = response.json()
-        return self.get(body["Id"])
+        container_id = response.json()["Id"]
+
+        return self.get(container_id)
 
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     @staticmethod

--- a/podman/domain/containers_manager.py
+++ b/podman/domain/containers_manager.py
@@ -31,6 +31,9 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         Args:
             container_id: Container name or id.
 
+        Returns:
+            A `Container` object corresponding to `key`.
+
         Raises:
             NotFound: when Container does not exist
             APIError: when an error return by service

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -77,7 +77,7 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         if log_type in ("json-file", "journald"):
             log_iter = container.logs(stdout=stdout, stderr=stderr, stream=True, follow=True)
 
-        exit_status = container.wait()["StatusCode"]
+        exit_status = container.wait()
         if exit_status != 0:
             log_iter = None
             if not kwargs.get("auto_remove", False):

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -6,14 +6,15 @@ try:
 except:
     # Python < 3.10
     from collections import Iterator
-from unittest.mock import patch, DEFAULT
+
+from unittest.mock import DEFAULT, patch
 
 import requests_mock
 
 from podman import PodmanClient, tests
 from podman.domain.containers import Container
 from podman.domain.containers_manager import ContainersManager
-from podman.errors import NotFound, ImageNotFound
+from podman.errors import ImageNotFound, NotFound
 
 FIRST_CONTAINER = {
     "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",

--- a/podman/tests/unit/test_containersmanager.py
+++ b/podman/tests/unit/test_containersmanager.py
@@ -276,7 +276,7 @@ class ContainersManagerTestCase(unittest.TestCase):
         )
 
         with patch.multiple(Container, logs=DEFAULT, wait=DEFAULT, autospec=True) as mock_container:
-            mock_container["wait"].return_value = {"StatusCode": 0}
+            mock_container["wait"].return_value = 0
 
             with self.subTest("Results not streamed"):
                 mock_container["logs"].return_value = iter(mock_logs)


### PR DESCRIPTION
This set of changes fixes the broken `.run()` capability, and adds some docstrings and clarifications along the way.

This fixes #201 and item 3 in #184.