### PR TITLE
Bump to v4.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-main} HEAD)
 HEAD ?= HEAD
 
-export PODMAN_VERSION ?= "4.3.0"
+export PODMAN_VERSION ?= "4.4.0"
 
 .PHONY: podman
 podman:

--- a/podman/version.py
+++ b/podman/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 __compatible_version__ = "1.40"


### PR DESCRIPTION
Bump the podman-py version to 4.4.0 to be in lockstep with podman versions.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>