### PR TITLE
Fix Container.stats behaviour

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -410,7 +410,7 @@ class Container(PodmanResource):
             "stream": stream,
         }
 
-        response = self.client.get("/containers/stats", params=params)
+        response = self.client.get("/containers/stats", params=params, stream=stream)
         response.raise_for_status()
 
         if stream:

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -3,7 +3,7 @@ import json
 import logging
 import shlex
 from contextlib import suppress
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple, Union
 
 import requests
 from requests import Response
@@ -389,7 +389,7 @@ class Container(PodmanResource):
         )
         response.raise_for_status()
 
-    def stats(self, **kwargs) -> Union[Sequence[Dict[str, bytes]], bytes]:
+    def stats(self, **kwargs) -> Iterator[Union[bytes, Dict[str, Any]]]:
         """Return statistics for container.
 
         Keyword Args:
@@ -419,9 +419,9 @@ class Container(PodmanResource):
 
     @staticmethod
     def _stats_helper(
-        decode: bool, body: List[Dict[str, Any]]
-    ) -> Iterator[Union[str, Dict[str, Any]]]:
-        """Helper needed to allow stats() to return either a generator or a str."""
+        decode: bool, body: Iterator[bytes]
+    ) -> Iterator[Union[bytes, Dict[str, Any]]]:
+        """Helper needed to allow stats() to return either a generator or a bytes."""
         for entry in body:
             if decode:
                 yield json.loads(entry)

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -1,5 +1,4 @@
 """Model and Manager for Container resources."""
-import io
 import json
 import logging
 import shlex
@@ -416,10 +415,7 @@ class Container(PodmanResource):
         if stream:
             return self._stats_helper(decode, response.iter_lines())
 
-        with io.StringIO() as buffer:
-            for entry in response.text:
-                buffer.write(json.dumps(entry) + "\n")
-            return buffer.getvalue()
+        return json.loads(response.text) if decode else response.content
 
     @staticmethod
     def _stats_helper(


### PR DESCRIPTION
Fixes #218 

The current behavior of the `Container.stats` method does not take into account the streaming mode, leading to it freezing when we use it in stream mode. It also has other issues regarding decoding even when its being used in a non-stream mode. This PR fixes those issues.

I've also updated some type-hints, which I think are wrongly typed.
Feel free to request changes if you think they are inappropriate.