### PR TITLE
Revert "Use modern tomllib/tomli modules for reading TOML files"

### DIFF
--- a/podman/domain/config.py
+++ b/podman/domain/config.py
@@ -1,20 +1,16 @@
 """Read containers.conf file."""
-import sys
 import urllib
 from pathlib import Path
 from typing import Dict, Optional
 
 import xdg.BaseDirectory
 
-from podman.api import cached_property
+try:
+    import toml
+except ImportError:
+    import pytoml as toml
 
-if sys.version_info >= (3, 11):
-    from tomllib import loads as toml_loads
-else:
-    try:
-        from tomli import loads as toml_loads
-    except ImportError:
-        from toml import loads as toml_loads
+from podman.api import cached_property
 
 
 class ServiceConnection:
@@ -68,7 +64,7 @@ class PodmanConfig:
         if self.path.exists():
             with self.path.open(encoding='utf-8') as file:
                 buffer = file.read()
-            self.attrs = toml_loads(buffer)
+            self.attrs = toml.loads(buffer)
 
     def __hash__(self) -> int:
         return hash(tuple(self.path.name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires = [
     "requests>=2.24",
     "setuptools>=46.4",
     "sphinx",
-    "tomli>=1.2.3; python_version<'3.11'",
+    "toml>=0.10.2",
     "urllib3>=1.26.5",
     "wheel",
 ]

--- a/python-podman.spec.rpkg
+++ b/python-podman.spec.rpkg
@@ -49,19 +49,19 @@ Source:     {{{ git_dir_pack }}}
 BuildRequires: git-core
 BuildRequires: python%{python3_pkgversion}-devel
 %if %{?old_rhel}
+BuildRequires: python%{python3_pkgversion}-pytoml
 BuildRequires: python%{python3_pkgversion}-pyxdg
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-setuptools
-BuildRequires: python%{python3_pkgversion}-toml
+Requires: python%{python3_pkgversion}-pytoml
 Requires: python%{python3_pkgversion}-pyxdg
 Requires: python%{python3_pkgversion}-requests
-Requires: python%{python3_pkgversion}-toml
 %else
 BuildRequires: pyproject-rpm-macros
 %endif
 %if 0%{?fedora} <= 35 && ! 0%{?rhel}
-BuildRequires: python%{python3_pkgversion}-tomli
-Requires: python%{python3_pkgversion}-tomli
+BuildRequires: python%{python3_pkgversion}-toml
+Requires: python%{python3_pkgversion}-toml
 %endif
 Provides: %{pypi_name}-py = %{version}-%{release}
 Summary: %{summary}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pyxdg>=0.26
 requests>=2.24
 setuptools
 sphinx
-tomli>=1.2.3; python_version<'3.11'
+toml>=0.10.2
 urllib3>=1.26.5
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ test_suite =
 install_requires =
     pyxdg >=0.26
     requests >=2.24
-    tomli>=1.2.3; python_version<'3.11'
+    toml >=0.10.2
     urllib3 >=1.26.5
 
 # typing_extensions are included for RHEL 8.5


### PR DESCRIPTION
This reverts commit c5a356fb4ea8a6fb66a6d20bdc2c9cffe615028b.

Reverting as there is packaging issues with the new toml library that was being added.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>