### PR TITLE
Specify version verbatim in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman
-version = attr: podman.version.__version__
+version = 4.4.1
 author = Brent Baude, Jhon Honce
 author_email = jhonce@redhat.com
 description = Bindings for Podman RESTful API


### PR DESCRIPTION
This restores compatibility with older setuptools versions.

NB, the version needs to be kept in sync between setup.cfg and version.py.

Relates: https://github.com/containers/podman-py/pull/244

