### PR TITLE
Fix stream issues in container.top

### DIFF
--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -11,6 +11,7 @@ from podman.api.parse_utils import (
     prepare_cidr,
     prepare_timestamp,
     stream_frames,
+    stream_helper,
 )
 from podman.api.tar_utils import create_tar, prepare_containerfile, prepare_containerignore
 from .. import version
@@ -58,4 +59,5 @@ __all__ = [
     'prepare_filters',
     'prepare_timestamp',
     'stream_frames',
+    'stream_helper',
 ]

--- a/podman/api/parse_utils.py
+++ b/podman/api/parse_utils.py
@@ -97,3 +97,14 @@ def stream_frames(response: Response) -> Iterator[bytes]:
         if not data:
             return
         yield data
+
+
+def stream_helper(
+    response: Response, decode_to_json: bool = False
+) -> Union[Iterator[bytes], Iterator[Dict[str, Any]]]:
+    """Helper to stream results and optionally decode to json"""
+    for value in response.iter_lines():
+        if decode_to_json:
+            yield json.loads(value)
+        else:
+            yield value

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -389,7 +389,9 @@ class Container(PodmanResource):
         )
         response.raise_for_status()
 
-    def stats(self, **kwargs) -> Iterator[Union[bytes, Dict[str, Any]]]:
+    def stats(
+        self, **kwargs
+    ) -> Union[bytes, Dict[str, Any], Iterator[bytes], Iterator[Dict[str, Any]]]:
         """Return statistics for container.
 
         Keyword Args:
@@ -413,20 +415,9 @@ class Container(PodmanResource):
         response.raise_for_status()
 
         if stream:
-            return self._stats_helper(decode, response.iter_lines())
+            return api.stream_helper(response, decode_to_json=decode)
 
-        return json.loads(response.text) if decode else response.content
-
-    @staticmethod
-    def _stats_helper(
-        decode: bool, body: Iterator[bytes]
-    ) -> Iterator[Union[bytes, Dict[str, Any]]]:
-        """Helper needed to allow stats() to return either a generator or a bytes."""
-        for entry in body:
-            if decode:
-                yield json.loads(entry)
-            else:
-                yield entry
+        return json.loads(response.content) if decode else response.content
 
     def stop(self, **kwargs) -> None:
         """Stop container.

--- a/podman/tests/unit/test_parse_utils.py
+++ b/podman/tests/unit/test_parse_utils.py
@@ -1,9 +1,12 @@
 import datetime
 import ipaddress
+import json
 import unittest
-from typing import Any, Optional
-
 from dataclasses import dataclass
+from typing import Any, Iterable, Optional, Tuple
+from unittest import mock
+
+from requests import Response
 
 from podman import api
 
@@ -14,7 +17,7 @@ class ParseUtilsTestCase(unittest.TestCase):
         class TestCase:
             name: str
             input: Any
-            expected: Optional[str]
+            expected: Tuple[str, Optional[str]]
 
         cases = [
             TestCase(name="empty str", input="", expected=("", None)),
@@ -56,11 +59,35 @@ class ParseUtilsTestCase(unittest.TestCase):
 
         self.assertEqual(api.prepare_timestamp(None), None)
         with self.assertRaises(ValueError):
-            api.prepare_timestamp("bad input")
+            api.prepare_timestamp("bad input")  # type: ignore
 
     def test_prepare_cidr(self):
         net = ipaddress.IPv4Network("127.0.0.0/24")
         self.assertEqual(api.prepare_cidr(net), ("127.0.0.0", "////AA=="))
+
+    def test_stream_helper(self):
+        streamed_results = [b'{"test":"val1"}', b'{"test":"val2"}']
+        mock_response = mock.Mock(spec=Response)
+        mock_response.iter_lines.return_value = iter(streamed_results)
+
+        streamable = api.stream_helper(mock_response)
+
+        self.assertIsInstance(streamable, Iterable)
+        for expected, actual in zip(streamed_results, streamable):
+            self.assertIsInstance(actual, bytes)
+            self.assertEqual(expected, actual)
+
+    def test_stream_helper_with_decode(self):
+        streamed_results = [b'{"test":"val1"}', b'{"test":"val2"}']
+        mock_response = mock.Mock(spec=Response)
+        mock_response.iter_lines.return_value = iter(streamed_results)
+
+        streamable = api.stream_helper(mock_response, decode_to_json=True)
+
+        self.assertIsInstance(streamable, Iterable)
+        for expected, actual in zip(streamed_results, streamable):
+            self.assertIsInstance(actual, dict)
+            self.assertDictEqual(json.loads(expected), actual)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes:
- Add a common `stream_helper` to stream and decode json responses
- Switches existing methods to use the newer helper.
- Fixes Container.top issues mentioned in #249 

The `stream_helper` would be useful when other APIs require streaming and JSON decoding like for the API mentioned  in #239

Please do let me know in case something needs to be changed or amended.

Closes #249 