### PR TITLE
Bump fixtures requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 -r requirements.txt
 black
 coverage
-fixtures~=3.0.0
+fixtures~=4.0.0
 pylint
 pytest
 requests-mock


### PR DESCRIPTION
CI is breaking due to a missing requirement on extras. This was dropped in newer versions.