### PR TITLE
Improve exception when missing env var

### DIFF
--- a/podman/client.py
+++ b/podman/client.py
@@ -113,6 +113,9 @@ class PodmanClient(AbstractContextManager):
 
         Returns:
             Client used to communicate with a Podman service.
+
+        Raises:
+            ValueError when required environment variable is not set
         """
         environment = environment or os.environ
         credstore_env = credstore_env or {}
@@ -121,6 +124,8 @@ class PodmanClient(AbstractContextManager):
             version = None
 
         host = environment.get("CONTAINER_HOST") or environment.get("DOCKER_HOST") or None
+        if host is None:
+            raise ValueError("CONTAINER_HOST or DOCKER_HOST must be set to URL of podman service.")
 
         return PodmanClient(
             base_url=host,

--- a/podman/tests/integration/test_system.py
+++ b/podman/tests/integration/test_system.py
@@ -57,3 +57,9 @@ class SystemIntegrationTest(base.IntegrationTest):
                 )
             )
         self.assertIn("lookup fake_registry: no such host", e.exception.explanation)
+
+    def test_from_env(self):
+        """integration: from_env() error message"""
+        with self.assertRaises(ValueError) as e:
+            next(self.client.from_env())
+        self.assertIn("CONTAINER_HOST or DOCKER_HOST", repr(e.exception))


### PR DESCRIPTION
When using from_env() and having not set one of the necessary env var.

```python
import podman
podman.from_env()
```

causes:

```ValueError: CONTAINER_HOST or DOCKER_HOST must be set to URL of podman service.```

fixes #223