### PR TITLE
Streaming support for PodsManager.stats API

### DIFF
--- a/podman/domain/pods_manager.py
+++ b/podman/domain/pods_manager.py
@@ -128,7 +128,7 @@ class PodsManager(Manager):
         response = self.client.delete(f"/pods/{pod_id}", params={"force": force})
         response.raise_for_status()
 
-    def stats(self, **kwargs) -> Union[Dict[str, Any], Iterator[Dict[str, Any]]]:
+    def stats(self, **kwargs) -> Union[List[Dict[str, Any]], Iterator[List[Dict[str, Any]]]]:
         """Resource usage statistics for the containers in pods.
 
         Keyword Args:

--- a/podman/tests/unit/test_podsmanager.py
+++ b/podman/tests/unit/test_podsmanager.py
@@ -156,7 +156,38 @@ class PodsManagerTestCase(unittest.TestCase):
         )
 
         actual = self.client.pods.stats(
-            name="c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8"
+            name="c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
+        )
+        self.assertEqual(actual, json.dumps(body).encode())
+
+    @requests_mock.Mocker()
+    def test_stats_without_decode(self, mock):
+        body = {
+            "Processes": [
+                [
+                    'jhonce',
+                    '2417',
+                    '2274',
+                    '0',
+                    'Mar01',
+                    '?',
+                    '00:00:01',
+                    '/usr/bin/ssh-agent /bin/sh -c exec -l /bin/bash -c "/usr/bin/gnome-session"',
+                ],
+                ['jhonce', '5544', '3522', '0', 'Mar01', 'pts/1', '00:00:02', '-bash'],
+                ['jhonce', '6140', '3522', '0', 'Mar01', 'pts/2', '00:00:00', '-bash'],
+            ],
+            "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME CMD"],
+        }
+        mock.get(
+            tests.LIBPOD_URL
+            + "/pods/stats"
+            "?namesOrIDs=c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
+            json=body,
+        )
+
+        actual = self.client.pods.stats(
+            name="c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8", decode=True
         )
         self.assertDictEqual(actual, body)
 


### PR DESCRIPTION
Podman API supports streaming Pod stats, but podman-py does not support that as of now.

This PR aims to add support for that.
