### PR TITLE
[v4.5-rhel] cherry-pick urlib3 fixes

### DIFF
--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -141,7 +141,8 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.assertIn(top_ctnr.id, report["ContainersDeleted"])
 
             # SpaceReclaimed is the size of the content created during the running of the container
-            self.assertEqual(report["SpaceReclaimed"], 0)
+            # TODO: This should probably check if the podman version is >= 4.6 (guess)
+            self.assertGreater(report["SpaceReclaimed"], 0)
 
             with self.assertRaises(NotFound):
                 self.client.containers.get(top_ctnr.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests>=2.24
 setuptools
 sphinx
 tomli>=1.2.3; python_version<'3.11'
-urllib3>=1.26.5
+urllib3>=1.26.5,<2.0.0
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pyxdg >=0.26
     requests >=2.24
     tomli>=1.2.3; python_version<'3.11'
-    urllib3 >=1.26.5
+    urllib3 >= 1.26.5, < 2.0.0
 
 # typing_extensions are included for RHEL 8.5
 # typing_extensions;python_version<'3.8'


### PR DESCRIPTION
 Revert "chore(deps): update dependency urllib3 to v2"
This reverts commit 6d37fea009233246d513c95041e8c67e4265f834.