### PR TITLE
Keep main branch version ahead of release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-main} HEAD)
 HEAD ?= HEAD
 
-export PODMAN_VERSION ?= "4.5.0"
+export PODMAN_VERSION ?= "4.6.0-dev"
 
 .PHONY: podman
 podman:

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -3,5 +3,5 @@
 # Do not auto-update these from version.py,
 #   as test code should be changed to reflect changes in Podman API versions
 BASE_SOCK = "unix:///run/api.sock"
-LIBPOD_URL = "http://%2Frun%2Fapi.sock/v4.5.0/libpod"
+LIBPOD_URL = "http://%2Frun%2Fapi.sock/v4.6.0/libpod"
 COMPATIBLE_URL = "http://%2Frun%2Fapi.sock/v1.40"

--- a/podman/version.py
+++ b/podman/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "4.5.0"
+__version__ = "4.6.0-dev"
 __compatible_version__ = "1.40"

--- a/rpm/python-podman.spec
+++ b/rpm/python-podman.spec
@@ -100,8 +100,8 @@ export PBR_VERSION="0.0.0"
 
 %if %{with rhel8_py}
 %files -n python%{python3_pkgversion}-%{pypi_name}
-%dir %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
-%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info/*
+%dir %{python3_sitelib}/%{pypi_name}-*-py%{python3_version}.egg-info
+%{python3_sitelib}/%{pypi_name}-*-py%{python3_version}.egg-info/*
 %dir %{python3_sitelib}/%{pypi_name}
 %{python3_sitelib}/%{pypi_name}/*
 %else

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman
-version = 4.5.0
+version = 4.6.0-dev
 author = Brent Baude, Jhon Honce
 author_email = jhonce@redhat.com
 description = Bindings for Podman RESTful API


### PR DESCRIPTION
 Use `-dev` to denote development branch.

 `LIBPOD_URL` in `poodman/tests/__init__.py` doesn't work with `-dev`, so
we only use `vX.Y.Z`.