### PR TITLE
Fix catching errors in the response body of containers/prune

### DIFF
--- a/podman/domain/containers_manager.py
+++ b/podman/domain/containers_manager.py
@@ -111,8 +111,12 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
 
         results = {"ContainersDeleted": [], "SpaceReclaimed": 0}
         for entry in response.json():
-            if entry.get("error") is not None:
-                raise APIError(entry["error"], response=response, explanation=entry["error"])
+            if entry.get("Err") is not None:
+                raise APIError(
+                    entry["Err"],
+                    response=response,
+                    explanation=f"""Failed to prune container '{entry["Id"]}'""",
+                )
 
             results["ContainersDeleted"].append(entry["Id"])
             results["SpaceReclaimed"] += entry["Size"]


### PR DESCRIPTION
Hi!

When `containers.prune()` is called, it currently fails silently since it looks for errors under the wrong key. The API returns it under the `Err` key and not the `error` key.

Tested using podman `4.5.1`.

Thank you! 