### PR TITLE
Includes the possibility to use the 'listTags' parameter in image search endpoint

### DIFF
--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -44,7 +44,6 @@ class ImagesManager(BuildMixin, Manager):
 
                 - dangling (bool)
                 - label (Union[str, List[str]]): format either "key" or "key=value"
-
         Raises:
             APIError: when service returns an error
         """
@@ -373,6 +372,7 @@ class ImagesManager(BuildMixin, Manager):
 
             noTrunc (bool): Do not truncate any result string. Default: True.
             limit (int): Maximum number of results.
+            listTags (bool): list the available tags in the repository. Default: False
 
         Raises:
             APIError: when service returns an error
@@ -383,6 +383,9 @@ class ImagesManager(BuildMixin, Manager):
             "noTrunc": True,
             "term": [term],
         }
+
+        if "listTags" in kwargs:
+            params["listTags"] = kwargs.get("listTags")
 
         response = self.client.get("/images/search", params=params)
         response.raise_for_status(not_found=ImageNotFound)

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -44,6 +44,7 @@ class ImagesManager(BuildMixin, Manager):
 
                 - dangling (bool)
                 - label (Union[str, List[str]]): format either "key" or "key=value"
+
         Raises:
             APIError: when service returns an error
         """

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -114,6 +114,9 @@ class ImagesIntegrationTest(base.IntegrationTest):
         self.assertEqual(len(actual), 1)
         self.assertEqual(actual[0]["Official"], "[OK]")
 
+        actual = self.client.images.search("alpine", listTags=True)
+        self.assertIsNotNone(actual[0]["Tag"])
+
     @unittest.skip("Needs Podman 3.1.0")
     def test_corrupt_load(self):
         with self.assertRaises(APIError) as e:

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -426,7 +426,7 @@ class ImagesManagerTestCase(unittest.TestCase):
                     "is_automated": False,
                     "name": "quay.io/libpod/fedora",
                     "star_count": 0,
-                    "tag": "1.0.0"
+                    "tag": "1.0.0",
                 },
             ],
         )

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -416,6 +416,28 @@ class ImagesManagerTestCase(unittest.TestCase):
         self.assertEqual(report[0]["name"], "quay.io/libpod/fedora")
 
     @requests_mock.Mocker()
+    def test_search_listTags(self, mock):
+        mock.get(
+            tests.LIBPOD_URL + "/images/search?term=fedora&noTrunc=true&listTags=true",
+            json=[
+                {
+                    "description": "mock term=fedora search",
+                    "is_official": False,
+                    "is_automated": False,
+                    "name": "quay.io/libpod/fedora",
+                    "star_count": 0,
+                    "tag": "1.0.0"
+                },
+            ],
+        )
+
+        report = self.client.images.search("fedora", listTags=True)
+        self.assertEqual(len(report), 1)
+
+        self.assertEqual(report[0]["name"], "quay.io/libpod/fedora")
+        self.assertEqual(report[0]["tag"], "1.0.0")
+
+    @requests_mock.Mocker()
     def test_push(self, mock):
         mock.post(tests.LIBPOD_URL + "/images/quay.io%2Ffedora%3Alatest/push")
 


### PR DESCRIPTION
From Podman 4.0, the endpoint for image search ([doc](https://docs.podman.io/en/latest/_static/api.html?version=v4.0#tag/images/operation/ImageSearchLibpod) ) includes the possibility to include a `listTags` (bool) parameter that allows the user get all the available tags for a specific image in the registry.

Similar suggestion (and solution) was raised in [Issue 264](https://github.com/containers/podman-py/issues/264).

The parameter is only included in the API request if the user includes it in the kwargs parameters for the function, so this change should not break anything if the user is interacting with some podman instance < 4.0.

Unit and integration tests have been included in the PR.

Signed-off-by: apozsuse <andres.munoz@suse.com>