### PR TITLE
Packit: mention `downstream_package_name: python-podman` in config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,6 +5,7 @@
 # Build targets can be found at:
 # https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
 
+downstream_package_name: python-podman
 specfile_path: rpm/python-podman.spec
 upstream_tag_template: v{version}
 


### PR DESCRIPTION
The Fedora package name doesn't match upstream name. As a result, packit cannot automatically detect the right package repo for downstream tasks unless downstream_package_name is specified.

Success can only be verified in the next upstream release.

Ref: https://packit.dev/docs/configuration#downstream_package_name