### PR TITLE
remove direct logging to sys.stderr

### DIFF
--- a/podman/domain/networks_manager.py
+++ b/podman/domain/networks_manager.py
@@ -10,7 +10,6 @@ Example:
 """
 import ipaddress
 import logging
-import sys
 from contextlib import suppress
 from typing import Any, Dict, List, Optional
 

--- a/podman/domain/networks_manager.py
+++ b/podman/domain/networks_manager.py
@@ -73,7 +73,6 @@ class NetworksManager(Manager):
             headers={"Content-Type": "application/json"},
         )
         response.raise_for_status()
-        sys.stderr.write(str(response.json()))
         return self.prepare_model(attrs=response.json())
 
     def _prepare_ipam(self, data: Dict[str, Any], ipam: Dict[str, Any]):


### PR DESCRIPTION
This direct logging to sys.stderr seems to happen only on this line. There is nowhere else in the code that does this.