### PR TITLE
Fixes the secrets parameter, adds the secret_env parameter

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -212,7 +212,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                     - As list of Secret objects the corresponding IDs are read from:
                         [Secret, Secret]
 
-                    - As list of dictionaries
+                    - As list of dictionaries:
                         [
                             {
                                 "source": "my_secret",  # A string representing the ID or name of
@@ -649,7 +649,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                 secret_opts = ["source", "target", "uid", "gid", "mode"]
                 for k, v in item.items():
                     if k in secret_opts:
-                        secret.update({k:v})
+                        secret.update({k: v})
                 params["secrets"].append(secret)
 
         if "secret_env" in args:

--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -103,7 +103,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             mounts (List[Mount]): Specification for mounts to be added to the container. More
                 powerful alternative to volumes. Each item in the list is expected to be a
                 Mount object.
-                For example :
+                For example:
                  [
                     {
                         "type": "bind",
@@ -202,7 +202,37 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                 For example: {"Name": "on-failure", "MaximumRetryCount": 5}
 
             runtime (str): Runtime to use with this container.
-            secrets (Union[List[Secret]|List[str]]): Secrets to add to this container.
+            secrets (List[Union[str, Secret, Dict[str, Union[str, int]]]]): Secrets to
+                mount to this container.
+
+                For example:
+                    - As list of strings, each string representing a secret's ID or name:
+                        ['my_secret', 'my_secret2']
+
+                    - As list of Secret objects the corresponding IDs are read from:
+                        [Secret, Secret]
+
+                    - As list of dictionaries
+                        [
+                            {
+                                "source": "my_secret",  # A string representing the ID or name of
+                                                        # a secret
+                                "target": "/my_secret", # An optional target to mount source to,
+                                                        # falls back to /run/secrets/source
+                                "uid": 1000,            # An optional UID that falls back to 0
+                                                        # if not given
+                                "gid": 1000,            # An optional GID that falls back to 0
+                                                        # if not given
+                                "mode": 0o400,          # An optional mode to apply to the target,
+                                                        # use an 0o prefix for octal integers
+                            },
+                        ]
+
+            secret_env (Dict[str, str]): Secrets to add as environment variables available in the
+                container.
+
+                For example: {"VARIABLE1": "NameOfSecret", "VARIABLE2": "NameOfAnotherSecret"}
+
             security_opt (List[str]): A List[str]ing values to customize labels for MLS systems,
                 such as SELinux.
             shm_size (Union[str, int]): Size of /dev/shm (e.g. 1G).
@@ -611,9 +641,19 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
 
         for item in args.pop("secrets", []):
             if isinstance(item, Secret):
-                params["secrets"].append({"ID": item.id})
+                params["secrets"].append({"source": item.id})
             elif isinstance(item, str):
-                params["secrets"].append({"ID": item})
+                params["secrets"].append({"source": item})
+            elif isinstance(item, dict):
+                secret = {}
+                secret_opts = ["source", "target", "uid", "gid", "mode"]
+                for k, v in item.items():
+                    if k in secret_opts:
+                        secret.update({k:v})
+                params["secrets"].append(secret)
+
+        if "secret_env" in args:
+            params["secret_env"] = args.pop("secret_env", {})
 
         if "cgroupns" in args:
             params["cgroupns"] = {"nsmode": args.pop("cgroupns")}


### PR DESCRIPTION
1. Minor fix

Minor typo fix out of context: "example :" to "example:"

2. Secrets

The previous implementation of the secrets parameter allowed a string or Secret object to be defined.
The parameter passed to the API resulted in {"ID":str}.

While testing the secrets API I found that having only a single secret defined worked fine while more than one secret resulted in an exception:

```
500 Server Error: Internal Server Error (more than one result secret with prefix : secret is ambiguous)
```

The parameter ID was never used and a prefix of "" (empty) assumed.
Having a single entry in the Secrets Manager will always result in a single result, no matter the filter.

After losing myself in the API documentation, the correct data format I found is the following:

```
{
    "source": "my_secret", # name or id
    "target": "/my_secret", # optional
    "uid": 1000, # optional
    "gid": 1000, # optional
    "mode": 0o400, # optional
}
```

No changes for existing setups are necessary. Data (str, object, dict) is still expected within a list.

3. Secrets as environment variables

I added the secret_env parameter to set a secret's content as environment variable:

```
{
  "var_name": "secret_name",
}
```

---

Inline documentation was updated. :-)