### PR TITLE
rename `working_dir` to `workdir` for consistency

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -4,6 +4,7 @@ import logging
 import re
 from contextlib import suppress
 from typing import Any, Dict, List, MutableMapping, Union
+import warnings
 
 from podman import api
 from podman.domain.containers import Container
@@ -287,7 +288,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                     }
 
             volumes_from (List[str]): List of container names or IDs to get volumes from.
-            working_dir (str): Path to the working directory.
+            workdir (str): Path to the working directory.
 
         Returns:
             A Container object.
@@ -403,6 +404,9 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                     f"or int (found : {size_type})"
                 )
 
+        if "working_dir" in args:
+            warnings.warn("working_dir is deprecated, use workdir instead", PendingDeprecationWarning)
+
         # Transform keywords into parameters
         params = {
             "annotations": pop("annotations"),  # TODO document, podman only
@@ -484,7 +488,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             "version": pop("version"),
             "volumes": [],
             "volumes_from": pop("volumes_from"),
-            "work_dir": pop("working_dir"),
+            "work_dir": pop("workdir") or pop("working_dir"),
         }
 
         for device in args.pop("devices", []):

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -322,6 +322,12 @@ class ContainersIntegrationTest(base.IntegrationTest):
                     print(inspect)
                     self.assertIn(expected_output, logs)
 
+    def test_container_working_dir_deprecation(self):
+        with self.assertWarns(PendingDeprecationWarning):
+            self.client.containers.create(
+                self.alpine_image, working_dir="/tmp", command=["/bin/ls", "-l", "/"]
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently `podman-py` uses all three versions of `work_dir`, `working_dir` and `workdir` (not to mention `WorkingDir`).

This commit tries to unify the parameter usage by allowing `workdir` for container `create` or `run`. For backwards compatibility `working_dir` still works but a deprecation warning is added.

Since upstream Podman uses a variety of *workdir* versions the `podman-py` codebase can't be simplified further.

Fix: #330