### PR TITLE
Fix readthedocs build issues

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    pre_build:
+      - sphinx-apidoc --separate --no-toc --force --templatedir docs/source/_templates/apidoc -o docs/source/ podman podman/tests
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,9 @@ release:
 
 .PHONY: docs
 docs:
-	mkdir -p _build/doctrees
-	cp -R docs/source/* _build/doctrees
-	sphinx-apidoc --separate --no-toc --force --templatedir build/docs/source/_templates/apidoc \
-		-o _build/doctrees \
-		podman podman/tests
-	# Previous Command: sphinx-build _build/doctrees _build/html
-	#
+	sphinx-apidoc --separate --no-toc --force --templatedir docs/source/_templates/apidoc \
+		-o docs/source/ podman podman/tests
+
 	# HARD CODED COMMAND from readthedocs! We must conform!
 	# -T : traceback
 	# -E : do not use saved environment, always read all files
@@ -76,7 +72,7 @@ docs:
 	# -D language=en : define language as en
 	# . : source directory
 	# _build/html : target
-	python3 -m sphinx -T -E -W --keep-going -b html -d _build/doctrees -D language=en _build/doctrees _build/html
+	cd docs/source && python3 -m sphinx -T -E -W --keep-going -b html -d _build/doctrees -D language=en . _build/html
 
 .PHONY: rpm
 rpm: ## Build rpm packages

--- a/docs/source/_templates/apidoc/module.rst_t
+++ b/docs/source/_templates/apidoc/module.rst_t
@@ -1,9 +1,14 @@
 {%- if show_headings %}
-{{- basename | replace("podman.", "") | e | heading }}
-
+{%- if "podman.errors" in basename %}
+{{- basename | replace("podman.errors.", "") | e | heading }}
+{% elif "podman.client" in basename -%}
+{{- basename | replace("podman.client", "client") | e | heading }}
+{% else -%}
+{{- basename | replace("podman.domain.", "") | e | heading }}
 {% endif -%}
+{% endif -%}
+
 .. automodule:: {{ qualname }}
 {%- for option in automodule_options %}
    :{{ option }}:
 {%- endfor %}
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,7 @@ exclude_patterns = [
     'podman.version.rst',
     'podman.tlsconfig.rst',
     'podman.errors.rst',
+    'podman.domain.rst',
 ]
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ Example
 
 .. toctree::
    :caption: Podman Client
-   :maxdepth: 2
+   :hidden:
 
    podman.client
 
@@ -53,21 +53,19 @@ Example
    :glob:
    :hidden:
 
-   podman.domain.config*
-   podman.domain.containers
-   podman.domain.containers_manager
-   podman.domain.images
-   podman.domain.images_manager
-   podman.domain.ipam*
-   podman.domain.events*
+   podman.domain.config
+   podman.domain.containers*
+   podman.domain.images*
+   podman.domain.ipam
+   podman.domain.events
    podman.domain.manager
-   podman.domain.manifests*
+   podman.domain.manifests
    podman.domain.networks*
    podman.domain.pods*
-   podman.domain.registry_data*
-   podman.domain.secrets*
-   podman.domain.system*
-   podman.domain.volume*
+   podman.domain.registry_data
+   podman.domain.secrets
+   podman.domain.system
+   podman.domain.volumes
    podman.errors.exceptions
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx
 tomli>=1.2.3; python_version<'3.11'
 urllib3
 wheel
+rich >= 12.5.1


### PR DESCRIPTION
When the docs were being built on readthedocs, they weren't showing up because it couldn't find where the generated rst files were. Fix that and update how the titles are shown in the sidebar.