### PR TITLE
Fix the 'max_pool_size' parameter passing for Adapters

### DIFF
--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -89,7 +89,7 @@ class APIClient(requests.Session):
         num_pools: Optional[int] = None,
         credstore_env: Optional[Mapping[str, str]] = None,
         use_ssh_client=True,
-        max_pools_size=None,
+        max_pool_size=None,
         **kwargs,
     ):  # pylint: disable=unused-argument
         """Instantiate APIClient object.
@@ -119,8 +119,8 @@ class APIClient(requests.Session):
         adapter_kwargs = kwargs.copy()
         if num_pools is not None:
             adapter_kwargs["pool_connections"] = num_pools
-        if max_pools_size is not None:
-            adapter_kwargs["pool_maxsize"] = max_pools_size
+        if max_pool_size is not None:
+            adapter_kwargs["pool_maxsize"] = max_pool_size
         if timeout is not None:
             adapter_kwargs["timeout"] = timeout
 

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -132,11 +132,15 @@ class APIClient(requests.Session):
         # and the below section is needed for backward compatible.
         # This section can be removed in a future release.
         if max_pools_size is not None:
-            warnings.warn("'max_pools_size' parameter is deprecated! "
-                          "Please use 'max_pool_size' parameter.", DeprecationWarning)
+            warnings.warn(
+                "'max_pools_size' parameter is deprecated! Please use 'max_pool_size' parameter.",
+                DeprecationWarning,
+            )
             if max_pool_size is not None:
-                raise ValueError("Both of 'max_pools_size' and 'max_pool_size' parameters are set. "
-                                 "Please use only the 'max_pool_size', 'max_pools_size' is deprecated!")
+                raise ValueError(
+                    "Both of 'max_pools_size' and 'max_pool_size' parameters are set. "
+                    "Please use only the 'max_pool_size', 'max_pools_size' is deprecated!"
+                )
             max_pool_size = max_pools_size
 
         if num_pools is not None:

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -28,8 +28,15 @@ _Data = Union[
 _Timeout = Union[None, float, Tuple[float, float], Tuple[float, None]]
 """Type alias for request timeout parameter."""
 
-# Make the DeprecationWarning visible for user.
-warnings.simplefilter('always', DeprecationWarning)
+
+class ParameterDeprecationWarning(DeprecationWarning):
+    """
+    Custom DeprecationWarning for deprecated parameters.
+    """
+
+
+# Make the ParameterDeprecationWarning visible for user.
+warnings.simplefilter('always', ParameterDeprecationWarning)
 
 
 class APIResponse:
@@ -134,7 +141,7 @@ class APIClient(requests.Session):
         if max_pools_size is not None:
             warnings.warn(
                 "'max_pools_size' parameter is deprecated! Please use 'max_pool_size' parameter.",
-                DeprecationWarning,
+                ParameterDeprecationWarning,
             )
             if max_pool_size is not None:
                 raise ValueError(


### PR DESCRIPTION
The `max_pool_size` was typed `max_pools_size`  in the `APIClient` class and it caused issue.

**Test code:**

```python
import podman
import requests
client = podman.from_env()
```

**Output:**

```text
>>> python3 test.py

Traceback (most recent call last):
  File "/local/user/podman_test/tools/test.py", line 11, in <module>
    client = podman.from_env()
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/client.py", line 131, in from_env
    return PodmanClient(
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/client.py", line 77, in __init__
    self.api = APIClient(**api_kwargs)
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/api/client.py", line 136, in __init__
    self.mount("http://", HTTPAdapter(**adapter_kwargs))
TypeError: __init__() got an unexpected keyword argument 'max_pool_size'
```


If I set the `max_pool_size` parameter in the `from_env` method (`client = podman.from_env(max_pool_size=requests.adapters.DEFAULT_POOLSIZE)`), the output is (the same):


```text
Traceback (most recent call last):
  File "/local/user/podman_test/tools/test.py", line 12, in <module>
    client = podman.from_env(max_pool_size=requests.adapters.DEFAULT_POOLSIZE)
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/client.py", line 131, in from_env
    return PodmanClient(
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/client.py", line 77, in __init__
    self.api = APIClient(**api_kwargs)
  File "/local/user/podman_test/venv/lib/python3.9/site-packages/podman/api/client.py", line 136, in __init__
    self.mount("http://", HTTPAdapter(**adapter_kwargs))
TypeError: __init__() got an unexpected keyword argument 'max_pool_size'
```

If I use `max_pools_size` instead of `max_pool_size`, the output is:

```text
Traceback (most recent call last):
  File "/local/user/podman_test/test.py", line 12, in <module>
    client = podman.from_env(max_pools_size=requests.adapters.DEFAULT_POOLSIZE)
TypeError: from_env() got an unexpected keyword argument 'max_pools_size'
```

Based on the above analysis, it's clearly visible the parameter passing is not correct...

Furthermore the implementation and the docstring are not matched (pool -> pools):

![implementation and docstring confusion](https://github.com/containers/podman-py/assets/62033726/a5250081-b51f-45ab-879d-dd414ea06026)

I have check the complete source code and I haven't found reference for `max_pools_size` parameter so I think my change is compatible with the source code.

**Note:**
- If a user uses the `APIClient` directly and the `max_pools_size` parameter is passed, then that implementation won't be working after my change because the parameter is renamed. But it can be made for backward compatible is it's preferred.

**The tested system:**
- Python 3.9.17
- RHEL 8.7 OS
- podman 4.8.2
