### PR TITLE
Add `workdir` as alias for `working_dir`

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -331,6 +331,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
 
             volumes_from (List[str]): List of container names or IDs to get volumes from.
             working_dir (str): Path to the working directory.
+            workdir (str): Alias of working_dir - Path to the working directory.
 
         Returns:
             A Container object.
@@ -525,7 +526,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             "version": pop("version"),
             "volumes": [],
             "volumes_from": pop("volumes_from"),
-            "work_dir": pop("working_dir"),
+            "work_dir": pop("workdir") or pop("working_dir"),
         }
 
         for device in args.pop("devices", []):


### PR DESCRIPTION
Currently `podman-py` uses all three versions of `work_dir`, `working_dir` and `workdir` (not to mention `WorkingDir`).

This commit tries to unify the parameter usage by allowing `workdir` for container `create` or `run`. For backwards compatibility `working_dir` still works.

Since upstream Podman uses a variety of *workdir* versions the `podman-py` codebase can't be simplified further.

Fix: #330