### PR TITLE
Fixes `X-Registry-Auth` encoding from base64 to url_safe base64

### DIFF
--- a/podman/api/http_utils.py
+++ b/podman/api/http_utils.py
@@ -99,4 +99,4 @@ def _filter_values(mapping: Mapping[str, Any], recursion=False) -> Dict[str, Any
 
 
 def encode_auth_header(auth_config: Dict[str, str]) -> str:
-    return base64.b64encode(json.dumps(auth_config).encode('utf-8'))
+    return base64.urlsafe_b64encode(json.dumps(auth_config).encode('utf-8'))


### PR DESCRIPTION

## Issue

For authentication for push/pull operations over registries, the value the `X-Registry-Auth` HTTP header is the base64 encoded of the json dump of the authorization data.
Plain base64 encoding causes problems if `+` character is present in the base64 encoded value, as `+` is a special separator in HTTP headers. The request is rejected by registries if '+' is present in that base64 encoded data.

## Fix
It's required to change the plain base64 encoding for `url_safe` base64 encoding, as this encoding avoid using the problematic characters for HTTP and that's the encoding the registries  are expecting.

The base64 `url_safe` encoding is present already in [podman client](https://github.com/containers/podman/blob/5c39ddca5dc7ac026ba4eacfd271450e7d0c7008/pkg/auth/auth.go#L213) or [docker](https://github.com/docker/cli/blob/b8d5454963fd52b4ab305e5a473223878b157f5b/cli/command/registry.go#L178) or [docker-py](https://github.com/docker/docker-py/blob/3d79ce8c603bd26e452e115c08aa4c670cc5ba54/docker/auth.py#L328).  

# Tests

According to my tests, `+` appears in base64 encoded when punctuation characters are encoded, for example:

```json
{
    "username": "'I(Bx}yr}~Dk",
    "password": "dycioxoqngpm",
    "email": "izcmhquyprda@domain.com",
    "serveraddress": "exwandvyvhqy"
}
```
Gets base64 encoded, showing the issue, as:
```
eyJ1c2VybmFtZSI6ICInSShCeH15cn1+RGsiLCAicGFzc3dvcmQiOiAiZHljaW94b3FuZ3BtIiwgImVtYWlsIjogIml6Y21ocXV5cHJkYUBkb21haW4uY29tIiwgInNlcnZlcmFkZHJlc3MiOiAiZXh3YW5kdnl2aHF5In0=
```
