### PR TITLE
Fix dns_option typo

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -460,7 +460,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             "conmon_pid_file": pop("conmon_pid_file"),  # TODO document, podman only
             "containerCreateCommand": pop("containerCreateCommand"),  # TODO document, podman only
             "devices": [],
-            "dns_options": pop("dns_opt"),
+            "dns_option": pop("dns_opt"),
             "dns_search": pop("dns_search"),
             "dns_server": pop("dns"),
             "entrypoint": pop("entrypoint"),


### PR DESCRIPTION
The Podman API clarifies the field to give is `dns_option`, not `dns_options` [here](https://docs.podman.io/en/stable/_static/api.html?version=v4.5#tag/containers/operation/ContainerCreateLibpod), so we need to drop the `s` to allow `dns_opt` fields to properly populate.

I thought about writing more unit tests for `containers_create.py` but there weren't existing tests for any of the options yet, so we'll have to add them for each API option I'd think.

Test program:
```python
import json
from podman import PodmanClient

uri='unix:///run/user/1000/podman/podman.sock'

with PodmanClient(base_url=uri) as client:
    container = client.containers.create(
        image='registry.access.redhat.com/ubi8',
        command=['sleep 500'],
        dns_opt=['edns0'],
    )
```
Now properly works since we're passing in the right name:
```bash
$ podman --remote --url=unix://run/user/1000/podman/podman.sock ps -a
CONTAINER ID  IMAGE                                   COMMAND     CREATED        STATUS      PORTS       NAMES
211024bb2e5b  registry.access.redhat.com/ubi8:latest  sleep 500   5 seconds ago  Created                 silly_merkle

$ podman inspect silly_merkle | jq '.[].HostConfig.DnsOptions'
[
  "edns0"
]
```
Note that it looks like `tox` is failing for unrelated reasons; I'm hoping the CI will have different results and it's just a local problem.