### PR TITLE
Fix Pylint E0606 for undefined variable after else

### DIFF
--- a/podman/domain/config.py
+++ b/podman/domain/config.py
@@ -81,6 +81,7 @@ class PodmanConfig:
             self.is_default = True
         else:
             self.path = Path(path)
+            old_toml_file = None
 
         self.attrs = {}
         if self.path.exists():


### PR DESCRIPTION
Description is trivial: `old_toml_file` is undefined in the else block.