### PR TITLE
[skip-ci] Packit: use default `update_release` behavior

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,6 @@
 # https://packit.dev/docs/configuration/
 
 downstream_package_name: python-podman
-update_release: false
 upstream_tag_template: v{version}
 
 packages:


### PR DESCRIPTION
The release needs to be updated if you're building for a persistent copr otherwise you'll end up with multiple builds with no change in the release tag.
See recent builds at: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/package/python-podman/ Ref Build IDs: 7478065, 7455330, 7446571

Packit by default updates the Release in spec file for copr builds which is what we want.