### PR TITLE
Remove Fedora release number from task names

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,6 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
-    FEDORA_NAME: "fedora-39"
-
     # Google-cloud VM Images
     IMAGE_SUFFIX: "c20240320t153921z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-podman-py-${IMAGE_SUFFIX}"
@@ -51,7 +49,7 @@ gating_task:
         - make lint
 
 test_task:
-    name: "Test on $FEDORA_NAME"
+    name: "Test on Fedora"
     alias: test
 
     depends_on:
@@ -64,7 +62,7 @@ test_task:
         - ${SCRIPT_BASE}/test.sh
 
 latest_task:
-    name: "Test Podman main on $FEDORA_NAME"
+    name: "Test Podman main on Fedora"
     alias: latest
     allow_failures: true
 


### PR DESCRIPTION
With Renovate managing CI VM updates, when a major Fedora release happens, additional manual work is required to update the CI task names so they match the release number.  This is extra burdensome on maintainers, stop it.

Example Ref: https://github.com/containers/podman-py/pull/389