### PR TITLE
Add ssh env variables to tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ setenv =
     PODMAN_LOG_LEVEL = {env:PODMAN_LOG_LEVEL:INFO}
     PODMAN_BINARY = {env:PODMAN_BINARY:podman}
     DEBUG = {env:DEBUG:0}
+    SSH_AUTH_SOCK={env:SSH_AUTH_SOCK}
+    SSH_AGENT_PID={env:SSH_AGENT_PID}
+    ssh-agent = yes
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
For users who have a ssh key protected by passphrase tests can hang and fail on 'Enter passphrase for key' if the correct ssh agent env variable is not set in tox.