### PR TITLE
Fix the locally non-existent image fails with AttributeError

### DIFF
--- a/podman/client.py
+++ b/podman/client.py
@@ -138,7 +138,7 @@ class PodmanClient(AbstractContextManager):
     @cached_property
     def containers(self) -> ContainersManager:
         """Returns Manager for operations on containers stored by a Podman service."""
-        return ContainersManager(client=self.api)
+        return ContainersManager(client=self.api, podman_client=self)
 
     @cached_property
     def images(self) -> ImagesManager:

--- a/podman/domain/containers_manager.py
+++ b/podman/domain/containers_manager.py
@@ -30,7 +30,7 @@ class ContainersManager(RunMixin, CreateMixin, Manager):
         """Get container by name or id.
 
         Args:
-            container_id: Container name or id.
+            key: Container name or id.
 
         Returns:
             A `Container` object corresponding to `key`.

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -60,7 +60,7 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         try:
             container = self.create(image=image, command=command, **kwargs)
         except ImageNotFound:
-            self.client.images.pull(image, platform=kwargs.get("platform"))
+            self.podman_client.images.pull(image, platform=kwargs.get("platform"))
             container = self.create(image=image, command=command, **kwargs)
 
         container.start()

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -209,7 +209,9 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+            "X-Registry-Auth": encode_auth_header(auth_config)
+            if auth_config
+            else ""
         }
 
         params = {
@@ -296,7 +298,9 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+            "X-Registry-Auth": encode_auth_header(auth_config)
+            if auth_config
+            else ""
         }
 
         params = {
@@ -309,7 +313,8 @@ class ImagesManager(BuildMixin, Manager):
         else:
             params["reference"] = f"{repository}:{tag}"
 
-        if "platform" in kwargs:
+        # Check if "platform" in kwargs AND it has value.
+        if "platform" in kwargs and kwargs["platform"]:
             tokens = kwargs.get("platform").split("/")
             if 1 < len(tokens) > 3:
                 raise ValueError(f'\'{kwargs.get("platform")}\' is not a legal platform.')

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -209,9 +209,7 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config)
-            if auth_config
-            else ""
+            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
         }
 
         params = {
@@ -298,9 +296,7 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config)
-            if auth_config
-            else ""
+            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
         }
 
         params = {


### PR DESCRIPTION
The code for running a new container with an image that is not present locally tries to access the `ImagesManager` via `self.client.images`.
As `self.client` is an `APIClient` instance and not an instance of `PodmanClient`, an `AttributeError` occurs:

```python
AttributeError: 'APIClient' object has no attribute 'images'
```

With this fix the `PodmanClient` object is used instead of `APIClinet` correctly.

**A very minimal test code:**

```python
import podman

with podman.PodmanClient() as client:
    client.containers.run("docker.io/library/busybox:latest")
```

The above code failed with `AttributeError` before my fix. Currently it pulls the Image if it's not available in local and run the container.

**Note:**
-  I guess the other `@cached_property` methods also can be extended with my solution if it's needed. I have extended only the `ContainersManager` with `podman_client` argument.

It's fix for:
https://github.com/containers/podman-py/issues/378