### PR TITLE
Fix the TypeError exception in the images.prune method

### DIFF
--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -224,6 +224,15 @@ class ImagesManagerTestCase(unittest.TestCase):
         self.assertEqual(e.exception.explanation, "Test prune failure in response body.")
 
     @requests_mock.Mocker()
+    def test_prune_empty(self, mock):
+        """Unit test if prune API responses null (None)."""
+        mock.post(tests.LIBPOD_URL + "/images/prune", text="null")
+
+        report = self.client.images.prune()
+        self.assertEqual(report["ImagesDeleted"], [])
+        self.assertEqual(report["SpaceReclaimed"], 0)
+
+    @requests_mock.Mocker()
     def test_get(self, mock):
         mock.get(
             tests.LIBPOD_URL + "/images/fedora%3Alatest/json",


### PR DESCRIPTION
If the prune doesn't remove images, the API returns `null` (with `200` status code) and it's interpreted as `None` (`NoneType`) so the for loop throws the following exception:

```
"TypeError: 'NoneType' object is not iterable".
```

My fix handles the above described case and the `client.images.prune()` returns a valid Dict with zero values, which is correct because the Podman didn't remove anything:

```python
{
    "ImagesDeleted": [],
    "SpaceReclaimed": 0,
}
```

**It's fix for:**
 - https://github.com/containers/podman-py/issues/275