### PR TITLE
[skip-ci] Packit: downstream_package_name for each package key

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,15 +2,16 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-downstream_package_name: python-podman
 upstream_tag_template: v{version}
 
 packages:
   python-podman-fedora:
     pkg_tool: fedpkg
+    downstream_package_name: python-podman
     specfile_path: rpm/python-podman.spec
   python-podman-centos:
     pkg_tool: centpkg
+    downstream_package_name: python-podman
     specfile_path: rpm/python-podman.spec
   python-podman-rhel:
     specfile_path: rpm/python-podman.spec


### PR DESCRIPTION
When the fedora package name doesn't match with the upstream repo, the `downstream_package_name` key needs to be mentioned for each package config (fedora, centos).