### PR TITLE
Extend the parameters of 'images.load' and 'login' methods

### DIFF
--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -320,6 +320,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -394,6 +395,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -412,6 +414,7 @@ class APIClient(requests.Session):
         # TODO should we have an option for HTTPS support?
         # Build URL for operation from base_url
         uri = urllib.parse.ParseResult(
+            # TODO: Does it make sense: "https" if kwargs.get("verify", None) else "http" ?
             "http",
             self.base_url.netloc,
             urllib.parse.urljoin(path_prefix, path),
@@ -429,6 +432,7 @@ class APIClient(requests.Session):
                     data=data,
                     headers=(headers or {}),
                     stream=stream,
+                    verify=kwargs.get("verify", None),
                     **timeout_kw,
                 )
             )

--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -411,11 +411,10 @@ class APIClient(requests.Session):
 
         path = path.lstrip("/")  # leading / makes urljoin crazy...
 
-        # TODO should we have an option for HTTPS support?
+        scheme = "https" if kwargs.get("verify", None) else "http"
         # Build URL for operation from base_url
         uri = urllib.parse.ParseResult(
-            # TODO: Does it make sense: "https" if kwargs.get("verify", None) else "http" ?
-            "http",
+            scheme,
             self.base_url.netloc,
             urllib.parse.urljoin(path_prefix, path),
             self.base_url.params,

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -6,8 +6,8 @@ import logging
 import os
 import urllib.parse
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
-import requests
 from pathlib import Path
+import requests
 
 from podman import api
 from podman.api import Literal
@@ -142,7 +142,8 @@ class ImagesManager(BuildMixin, Manager):
 
         # Load a tarball containing the image
         if file_path:
-            # Convert to Path if file_path is a string (This works with both str and Path-like objects)
+            # Convert to Path if file_path is a string
+            # (This works with both str and Path-like objects)
             file_path = Path(file_path)
             data = file_path.read_bytes()  # Read the tarball file as bytes
 

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -117,7 +117,7 @@ class ImagesManager(BuildMixin, Manager):
 
     def load(
         self, data: Optional[bytes] = None, file_path: Optional[os.PathLike] = None
-    ) -> List[Image, None, None]:
+    ) -> List[Image]:
         """Restore an image previously saved.
 
         Args:

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -49,7 +49,6 @@ class SystemManager:
         registrytoken: Optional[str] = None,
         tls_verify: Optional[Union[bool, str]] = None,
     ) -> Dict[str, Any]:
-
         """Log into Podman service.
 
         Args:

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -48,7 +48,7 @@ class SystemManager:
         identitytoken: Optional[str] = None,
         registrytoken: Optional[str] = None,
         tls_verify: Optional[Union[bool, str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:  # pylint: disable=too-many-arguments
         """Log into Podman service.
 
         Args:

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -36,7 +36,7 @@ class SystemManager:
         response.raise_for_status()
         return response.json()
 
-    def login(
+    def login(  # pylint: disable=too-many-arguments
         self,
         username: str,
         password: Optional[str] = None,
@@ -48,7 +48,7 @@ class SystemManager:
         identitytoken: Optional[str] = None,
         registrytoken: Optional[str] = None,
         tls_verify: Optional[Union[bool, str]] = None,
-    ) -> Dict[str, Any]:  # pylint: disable=too-many-arguments
+    ) -> Dict[str, Any]:
         """Log into Podman service.
 
         Args:

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -36,8 +36,7 @@ class SystemManager:
         response.raise_for_status()
         return response.json()
 
-    # pylint: disable=too-many-arguments,unused-argument
-    def login(
+    def login(  # pylint: disable=too-many-arguments,unused-argument
         self,
         username: str,
         password: Optional[str] = None,
@@ -50,6 +49,7 @@ class SystemManager:
         registrytoken: Optional[str] = None,
         tls_verify: Optional[Union[bool, str]] = None,
     ) -> Dict[str, Any]:
+
         """Log into Podman service.
 
         Args:

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -60,7 +60,8 @@ class SystemManager:
             dockercfg_path: Ignored: Path to custom configuration file.
                 https://quay.io/v2
             auth = None,
-            identitytoken: IdentityToken is used to authenticate the user and get an access token for the registry.
+            identitytoken: IdentityToken is used to authenticate the user and
+                           get an access token for the registry.
             registrytoken: RegistryToken is a bearer token to be sent to a registry
             tls_verify: Whether to verify TLS certificates.
         """

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -36,14 +36,15 @@ class SystemManager:
         response.raise_for_status()
         return response.json()
 
-    def login(  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,unused-argument
+    def login(
         self,
         username: str,
         password: Optional[str] = None,
         email: Optional[str] = None,
         registry: Optional[str] = None,
-        reauth: Optional[bool] = False,  # pylint: disable=unused-argument
-        dockercfg_path: Optional[str] = None,  # pylint: disable=unused-argument
+        reauth: Optional[bool] = False,
+        dockercfg_path: Optional[str] = None,
         auth: Optional[str] = None,
         identitytoken: Optional[str] = None,
         registrytoken: Optional[str] = None,

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -1,7 +1,7 @@
 """SystemManager to provide system level information from Podman service."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from podman.api.client import APIClient
 from podman import api
@@ -47,7 +47,7 @@ class SystemManager:
         auth: Optional[str] = None,
         identitytoken: Optional[str] = None,
         registrytoken: Optional[str] = None,
-        tls_verify: Optional[bool, str] = None,
+        tls_verify: Optional[Union[bool, str]] = None,
     ) -> Dict[str, Any]:
         """Log into Podman service.
 

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -37,7 +37,6 @@ class SystemManager:
         return response.json()
 
     def login(  # pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
-        main
         self,
         username: str,
         password: Optional[str] = None,

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -44,6 +44,10 @@ class SystemManager:
         registry: Optional[str] = None,
         reauth: Optional[bool] = False,  # pylint: disable=unused-argument
         dockercfg_path: Optional[str] = None,  # pylint: disable=unused-argument
+        auth: Optional[str] = None,
+        identitytoken: Optional[str] = None,
+        registrytoken: Optional[str] = None,
+        tls_verify: Optional[bool, str] = None,
     ) -> Dict[str, Any]:
         """Log into Podman service.
 
@@ -55,6 +59,10 @@ class SystemManager:
             reauth: Ignored: If True, refresh existing authentication. Default: False
             dockercfg_path: Ignored: Path to custom configuration file.
                 https://quay.io/v2
+            auth = None,
+            identitytoken: IdentityToken is used to authenticate the user and get an access token for the registry.
+            registrytoken: RegistryToken is a bearer token to be sent to a registry
+            tls_verify: Whether to verify TLS certificates.
         """
 
         payload = {
@@ -62,6 +70,9 @@ class SystemManager:
             "password": password,
             "email": email,
             "serveraddress": registry,
+            "auth": auth,
+            "identitytoken": identitytoken,
+            "registrytoken": registrytoken,
         }
         payload = api.prepare_body(payload)
         response = self.client.post(
@@ -69,6 +80,7 @@ class SystemManager:
             headers={"Content-type": "application/json"},
             data=payload,
             compatible=True,
+            verify=tls_verify,  # Pass tls_verify to the client
         )
         response.raise_for_status()
         return response.json()

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -59,7 +59,7 @@ class SystemManager:
             reauth: Ignored: If True, refresh existing authentication. Default: False
             dockercfg_path: Ignored: Path to custom configuration file.
                 https://quay.io/v2
-            auth = None,
+            auth: TODO: Add description based on the source code of Podman.
             identitytoken: IdentityToken is used to authenticate the user and
                            get an access token for the registry.
             registrytoken: RegistryToken is a bearer token to be sent to a registry

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -1,5 +1,6 @@
 import types
 import unittest
+from unittest.mock import mock_open, patch
 
 try:
     # Python >= 3.10
@@ -13,7 +14,7 @@ import requests_mock
 from podman import PodmanClient, tests
 from podman.domain.images import Image
 from podman.domain.images_manager import ImagesManager
-from podman.errors import APIError, ImageNotFound
+from podman.errors import APIError, ImageNotFound, PodmanError
 
 FIRST_IMAGE = {
     "Id": "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -320,6 +321,37 @@ class ImagesManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_load(self, mock):
+        with self.assertRaises(PodmanError):
+            self.client.images.load()
+
+        with self.assertRaises(PodmanError):
+            self.client.images.load(b'data', b'file_path')
+
+        with self.assertRaises(PodmanError):
+            self.client.images.load(data=b'data', file_path=b'file_path')
+
+        with patch("builtins.open", mock_open(read_data=b"mock tarball data")) as mock_file:
+            mock.post(
+                tests.LIBPOD_URL + "/images/load",
+                json={"Names": ["quay.io/fedora:latest"]},
+            )
+            mock.get(
+                tests.LIBPOD_URL + "/images/quay.io%2ffedora%3Alatest/json",
+                json=FIRST_IMAGE,
+            )
+
+            # 3a. Test the case where only 'file_path' is provided
+            gntr = self.client.images.load(file_path="mock_file.tar")
+            self.assertIsInstance(gntr, types.GeneratorType)
+
+            report = list(gntr)
+            self.assertEqual(len(report), 1)
+            self.assertEqual(
+                report[0].id,
+                "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
+            )
+            mock_file.assert_called_once_with("mock_file.tar", "rb")
+
         mock.post(
             tests.LIBPOD_URL + "/images/load",
             json={"Names": ["quay.io/fedora:latest"]},

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -322,13 +322,13 @@ class ImagesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_load(self, mock):
         with self.assertRaises(PodmanError):
-            next(self.client.images.load())
+            self.client.images.load()
 
         with self.assertRaises(PodmanError):
-            next(self.client.images.load(b'data', b'file_path'))
+            self.client.images.load(b'data', b'file_path')
 
         with self.assertRaises(PodmanError):
-            next(self.client.images.load(data=b'data', file_path=b'file_path'))
+            self.client.images.load(data=b'data', file_path=b'file_path')
 
         with patch("builtins.open", mock_open(read_data=b"mock tarball data")) as mock_file:
             mock.post(
@@ -341,13 +341,12 @@ class ImagesManagerTestCase(unittest.TestCase):
             )
 
             # 3a. Test the case where only 'file_path' is provided
-            gntr = self.client.images.load(file_path="mock_file.tar")
-            self.assertIsInstance(gntr, types.GeneratorType)
+            result_list = self.client.images.load(file_path="mock_file.tar")
+            self.assertIsInstance(result_list, list)
 
-            report = list(gntr)
-            self.assertEqual(len(report), 1)
+            self.assertEqual(len(result_list), 1)
             self.assertEqual(
-                report[0].id,
+                result_list[0].id,
                 "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
             )
             mock_file.assert_called_once_with("mock_file.tar", "rb")
@@ -361,13 +360,12 @@ class ImagesManagerTestCase(unittest.TestCase):
             json=FIRST_IMAGE,
         )
 
-        gntr = self.client.images.load(b'This is a weird tarball...')
-        self.assertIsInstance(gntr, types.GeneratorType)
+        result_list = self.client.images.load(b'This is a weird tarball...')
+        self.assertIsInstance(result_list, list)
 
-        report = list(gntr)
-        self.assertEqual(len(report), 1)
+        self.assertEqual(len(result_list), 1)
         self.assertEqual(
-            report[0].id, "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
+            result_list[0].id, "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
         )
 
     @requests_mock.Mocker()

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -322,13 +322,13 @@ class ImagesManagerTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_load(self, mock):
         with self.assertRaises(PodmanError):
-            self.client.images.load()
+            next(self.client.images.load())
 
         with self.assertRaises(PodmanError):
-            self.client.images.load(b'data', b'file_path')
+            next(self.client.images.load(b'data', b'file_path'))
 
         with self.assertRaises(PodmanError):
-            self.client.images.load(data=b'data', file_path=b'file_path')
+            next(self.client.images.load(data=b'data', file_path=b'file_path'))
 
         with patch("builtins.open", mock_open(read_data=b"mock tarball data")) as mock_file:
             mock.post(

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -365,7 +365,8 @@ class ImagesManagerTestCase(unittest.TestCase):
 
         self.assertEqual(len(result_list), 1)
         self.assertEqual(
-            result_list[0].id, "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab"
+            result_list[0].id,
+            "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
         )
 
     @requests_mock.Mocker()


### PR DESCRIPTION
The new parameters of `login` method based on [SystemAuth docs](https://docs.podman.io/en/latest/_static/api.html#tag/system-(compat)/operation/SystemAuth):

- **auth**
- **identitytoken**: IdentityToken is used to authenticate the user and get an access token for the registry.
- **registrytoken**: RegistryToken is a bearer token to be sent to a registry
- **tls_verify**: Whether to verify TLS certificates.

The new parameter of `images.load` method:

- **file_path**: Path of the Tarball. If it's set then the `load` method opens the file and reads it as bytes. It means the method is able to handle file path as well, not only bytes. The scenarios when none of parameters or both of them are set are handled in the method.

**Fix for:**

- https://github.com/containers/podman-py/issues/419