### PR TITLE
Remove the container in case of detach mode

### DIFF
--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -324,6 +324,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -400,6 +401,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -418,6 +420,7 @@ class APIClient(requests.Session):
         # TODO should we have an option for HTTPS support?
         # Build URL for operation from base_url
         uri = urllib.parse.ParseResult(
+            # TODO: Does it make sense: "https" if kwargs.get("verify", None) else "http" ?
             "http",
             self.base_url.netloc,
             urllib.parse.urljoin(path_prefix, path),
@@ -435,6 +438,7 @@ class APIClient(requests.Session):
                     data=data,
                     headers=(headers or {}),
                     stream=stream,
+                    verify=kwargs.get("verify", None),
                     **timeout_kw,
                 )
             )

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -1,6 +1,7 @@
 """Mixin to provide Container run() method."""
 
 import logging
+import threading
 from contextlib import suppress
 from typing import Generator, Iterator, List, Union
 
@@ -67,7 +68,20 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         container.start()
         container.reload()
 
+        def remove_container(container_object: Container) -> None:
+            """
+            Wait the container to finish and remove it.
+
+            Args:
+                container_object: Container object
+            """
+            container_object.wait()  # Wait for the container to finish
+            container_object.remove()  # Remove the container
+
         if kwargs.get("detach", False):
+            if remove:
+                # Start a background thread to remove the container after finishing
+                threading.Thread(target=remove_container, args=(container,)).start()
             return container
 
         with suppress(KeyError):

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -1,7 +1,7 @@
 """SystemManager to provide system level information from Podman service."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from podman.api.client import APIClient
 from podman import api
@@ -44,6 +44,10 @@ class SystemManager:
         registry: Optional[str] = None,
         reauth: Optional[bool] = False,  # pylint: disable=unused-argument
         dockercfg_path: Optional[str] = None,  # pylint: disable=unused-argument
+        auth: Optional[str] = None,
+        identitytoken: Optional[str] = None,
+        registrytoken: Optional[str] = None,
+        tls_verify: Optional[Union[bool, str]] = None,
     ) -> Dict[str, Any]:
         """Log into Podman service.
 
@@ -55,6 +59,11 @@ class SystemManager:
             reauth: Ignored: If True, refresh existing authentication. Default: False
             dockercfg_path: Ignored: Path to custom configuration file.
                 https://quay.io/v2
+            auth = None,
+            identitytoken: IdentityToken is used to authenticate the user and
+                           get an access token for the registry.
+            registrytoken: RegistryToken is a bearer token to be sent to a registry
+            tls_verify: Whether to verify TLS certificates.
         """
 
         payload = {
@@ -62,6 +71,9 @@ class SystemManager:
             "password": password,
             "email": email,
             "serveraddress": registry,
+            "auth": auth,
+            "identitytoken": identitytoken,
+            "registrytoken": registrytoken,
         }
         payload = api.prepare_body(payload)
         response = self.client.post(
@@ -69,6 +81,7 @@ class SystemManager:
             headers={"Content-type": "application/json"},
             data=payload,
             compatible=True,
+            verify=tls_verify,  # Pass tls_verify to the client
         )
         response.raise_for_status()
         return response.json()

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -1,5 +1,6 @@
 import types
 import unittest
+from unittest.mock import mock_open, patch
 
 try:
     # Python >= 3.10
@@ -13,7 +14,7 @@ import requests_mock
 from podman import PodmanClient, tests
 from podman.domain.images import Image
 from podman.domain.images_manager import ImagesManager
-from podman.errors import APIError, ImageNotFound
+from podman.errors import APIError, ImageNotFound, PodmanError
 
 FIRST_IMAGE = {
     "Id": "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
@@ -320,6 +321,37 @@ class ImagesManagerTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_load(self, mock):
+        with self.assertRaises(PodmanError):
+            self.client.images.load()
+
+        with self.assertRaises(PodmanError):
+            self.client.images.load(b'data', b'file_path')
+
+        with self.assertRaises(PodmanError):
+            self.client.images.load(data=b'data', file_path=b'file_path')
+
+        with patch("builtins.open", mock_open(read_data=b"mock tarball data")) as mock_file:
+            mock.post(
+                tests.LIBPOD_URL + "/images/load",
+                json={"Names": ["quay.io/fedora:latest"]},
+            )
+            mock.get(
+                tests.LIBPOD_URL + "/images/quay.io%2ffedora%3Alatest/json",
+                json=FIRST_IMAGE,
+            )
+
+            # 3a. Test the case where only 'file_path' is provided
+            gntr = self.client.images.load(file_path="mock_file.tar")
+            self.assertIsInstance(gntr, types.GeneratorType)
+
+            report = list(gntr)
+            self.assertEqual(len(report), 1)
+            self.assertEqual(
+                report[0].id,
+                "sha256:326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
+            )
+            mock_file.assert_called_once_with("mock_file.tar", "rb")
+
         mock.post(
             tests.LIBPOD_URL + "/images/load",
             json={"Names": ["quay.io/fedora:latest"]},


### PR DESCRIPTION
Currently if the `detach=True` and `remove=True` parameters are specified the container is not deleted.

**Reproduce the issue:**

```python
from podman import PodmanClient

uri = "unix:///run/user/1000/podman/podman.sock"

with PodmanClient(base_url=uri) as client:
    c = client.containers.run("nginx", deatch=True, remove=True, command="/bin/false")

    print(c.status)
```

With this change if the above parameters are provided then the container object is returned and the container removing (wait method is included) is started on a separated thread.

**Fix for:**

- https://github.com/containers/podman-py/issues/402
