### PR TITLE
domain/networks_manager.py: use specified driver in IPAMConfig

### DIFF
--- a/podman/domain/ipam.py
+++ b/podman/domain/ipam.py
@@ -40,7 +40,7 @@ class IPAMConfig(dict):
 
     def __init__(
         self,
-        driver: Optional[str] = "default",
+        driver: Optional[str] = "host-local",
         pool_configs: Optional[List[IPAMPool]] = None,
         options: Optional[Mapping[str, Any]] = None,
     ):

--- a/podman/domain/networks_manager.py
+++ b/podman/domain/networks_manager.py
@@ -76,6 +76,9 @@ class NetworksManager(Manager):
         return self.prepare_model(attrs=response.json())
 
     def _prepare_ipam(self, data: Dict[str, Any], ipam: Dict[str, Any]):
+        if "Driver" in ipam:
+            data["ipam_options"] = {"driver": ipam["Driver"]}
+
         if "Config" not in ipam:
             return
 


### PR DESCRIPTION
When user specifies a IPAM driver through IPAMConfig, the driver value was ignored and not translated to json used in network create command. This patch fixes the issue by translating the IPAM driver configuration in network_create json data.

Code to create network:
```
from podman import PodmanClient
from podman.domain.ipam import IPAMConfig

podman_client = PodmanClient(base_url="unix:///run/podman/podman.sock", timeout=60)

ipam_config = IPAMConfig(
    driver="none",
)
podman_client.networks.create(
    "lnst_container_net_net1",
    internal=True,
    enable_ipv6=True,
    ipam=ipam_config,
)
```

Before change 
```
# podman network inspect lnst_container_net_net1
[
     {
          "name": "lnst_container_net_net1",
          "id": "b3a290de4cfe29d4a06655689c02a8979ecf7a5c104f387b06f5dbc4b38abfb6",
          "driver": "bridge",
          "network_interface": "podman1",
          "created": "2024-09-17T14:14:44.286394253+02:00",
          "subnets": [
               {
                    "subnet": "10.89.0.0/24"
               },
               {
                    "subnet": "fd2a:574a:3e25:c8a4::/64"
               }
          ],
          "ipv6_enabled": true,
          "internal": true,
          "dns_enabled": false,
          "ipam_options": {
               "driver": "host-local"
          },
          "containers": {
               "0c761d34b6db602a3bd6c9452974eafeaa790c473a32f008b7e7f87c46329cfb": {
                    "name": "sleepy_fermat",
                    "interfaces": {
                         "eth1": {
                              "subnets": [
                                   {
                                        "ipnet": "10.89.0.2/24"
                                   },
                                   {
                                        "ipnet": "fd2a:574a:3e25:c8a4::2/64"
                                   }
                              ],
                              "mac_address": "52:c4:20:aa:32:d3"
                         }
                    }
               },
               "fafdd328fd8fc46e9104d77146fd660d29badb1b45bff2eac88442ba5b9386a2": {
                    "name": "adoring_gauss",
                    "interfaces": {
                         "eth1": {
                              "subnets": [
                                   {
                                        "ipnet": "10.89.0.1/24"
                                   },
                                   {
                                        "ipnet": "fd2a:574a:3e25:c8a4::1/64"
                                   }
                              ],
                              "mac_address": "1a:d0:8e:6b:8d:0a"
                         }
                    }
               }
          }
     }
]
```

After change:
```
# sudo podman network inspect lnst_container_net_net1
[
     {
          "name": "lnst_container_net_net1",
          "id": "45ef23430893e413e1365ce32e65f03d5a9b68e0c5239e3a173845f65dd2a588",
          "driver": "bridge",
          "network_interface": "podman1",
          "created": "2024-09-17T14:46:38.771124038+02:00",
          "ipv6_enabled": true,
          "internal": true,
          "dns_enabled": false,
          "ipam_options": {
               "driver": "none"
          },
          "containers": {
               "6bb7ce22fa585e18527ec93b4bd1306f10a6e5a0a609c6fed7c7cec62fda29e9": {
                    "name": "intelligent_turing",
                    "interfaces": {
                         "eth1": {
                              "mac_address": "66:0f:37:e5:26:60"
                         }
                    }
               },
               "84ece9c712c375d68896244d9f8d8d00a7faa0df8c610accc5ce6aeb7b404f44": {
                    "name": "naughty_pasteur",
                    "interfaces": {
                         "eth1": {
                              "mac_address": "32:7a:a2:b1:25:2d"
                         }
                    }
               }
          }
     }
]
```
