### PR TITLE
Extend the parameters of 'images.load' and 'login' methods

### DIFF
--- a/podman/api/client.py
+++ b/podman/api/client.py
@@ -324,6 +324,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -400,6 +401,7 @@ class APIClient(requests.Session):
 
         Keyword Args:
             compatible: Will override the default path prefix with compatible prefix
+            verify: Whether to verify TLS certificates.
 
         Raises:
             APIError: when service returns an error
@@ -415,10 +417,10 @@ class APIClient(requests.Session):
 
         path = path.lstrip("/")  # leading / makes urljoin crazy...
 
-        # TODO should we have an option for HTTPS support?
+        scheme = "https" if kwargs.get("verify", None) else "http"
         # Build URL for operation from base_url
         uri = urllib.parse.ParseResult(
-            "http",
+            scheme,
             self.base_url.netloc,
             urllib.parse.urljoin(path_prefix, path),
             self.base_url.params,
@@ -435,6 +437,7 @@ class APIClient(requests.Session):
                     data=data,
                     headers=(headers or {}),
                     stream=stream,
+                    verify=kwargs.get("verify", None),
                     **timeout_kw,
                 )
             )

--- a/podman/domain/system.py
+++ b/podman/domain/system.py
@@ -1,7 +1,7 @@
 """SystemManager to provide system level information from Podman service."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from podman.api.client import APIClient
 from podman import api
@@ -42,8 +42,12 @@ class SystemManager:
         password: Optional[str] = None,
         email: Optional[str] = None,
         registry: Optional[str] = None,
-        reauth: Optional[bool] = False,  # pylint: disable=unused-argument
-        dockercfg_path: Optional[str] = None,  # pylint: disable=unused-argument
+        reauth: Optional[bool] = False,
+        dockercfg_path: Optional[str] = None,
+        auth: Optional[str] = None,
+        identitytoken: Optional[str] = None,
+        registrytoken: Optional[str] = None,
+        tls_verify: Optional[Union[bool, str]] = None,
     ) -> Dict[str, Any]:
         """Log into Podman service.
 
@@ -55,6 +59,11 @@ class SystemManager:
             reauth: Ignored: If True, refresh existing authentication. Default: False
             dockercfg_path: Ignored: Path to custom configuration file.
                 https://quay.io/v2
+            auth: TODO: Add description based on the source code of Podman.
+            identitytoken: IdentityToken is used to authenticate the user and
+                           get an access token for the registry.
+            registrytoken: RegistryToken is a bearer token to be sent to a registry
+            tls_verify: Whether to verify TLS certificates.
         """
 
         payload = {
@@ -62,6 +71,9 @@ class SystemManager:
             "password": password,
             "email": email,
             "serveraddress": registry,
+            "auth": auth,
+            "identitytoken": identitytoken,
+            "registrytoken": registrytoken,
         }
         payload = api.prepare_body(payload)
         response = self.client.post(
@@ -69,6 +81,7 @@ class SystemManager:
             headers={"Content-type": "application/json"},
             data=payload,
             compatible=True,
+            verify=tls_verify,  # Pass tls_verify to the client
         )
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
The new parameters of login method based on [SystemAuth docs](https://docs.podman.io/en/latest/_static/api.html#tag/system-(compat)/operation/SystemAuth):

- **auth**: TBD description
- **identitytoken**: IdentityToken is used to authenticate the user and get an access token for the registry.
- **registrytoken**: RegistryToken is a bearer token to be sent to a registry
- **tls_verify**: Whether to verify TLS certificates.

The new parameter of images.load method:

- file_path: Path of the Tarball. If it's set then the load method opens the file and reads it as bytes. It means the method is able to handle file path as well, not only bytes. The scenarios when none of parameters or both of them are set are handled in the method.

**Fix for:**

- https://github.com/containers/podman-py/issues/419