### PR TITLE
Remove the container in case of detach mode

### DIFF
--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -1,6 +1,7 @@
 """Mixin to provide Container run() method."""
 
 import logging
+import threading
 from contextlib import suppress
 from typing import Generator, Iterator, List, Union
 
@@ -67,7 +68,19 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         container.start()
         container.reload()
 
+        def remove_container(container_object: Container) -> None:
+            """
+            Wait the container to finish and remove it.
+            Args:
+                container_object: Container object
+            """
+            container_object.wait()  # Wait for the container to finish
+            container_object.remove()  # Remove the container
+
         if kwargs.get("detach", False):
+            if remove:
+                # Start a background thread to remove the container after finishing
+                threading.Thread(target=remove_container, args=(container,)).start()
             return container
 
         with suppress(KeyError):


### PR DESCRIPTION
Currently if the `detach=True` and `remove=True` parameters are specified in  the same command, the container is not deleted.

**Reproduce the issue:**

```python
from podman import PodmanClient

uri = "unix:///run/user/1000/podman/podman.sock"

with PodmanClient(base_url=uri) as client:
    c = client.containers.run("nginx", deatch=True, remove=True, command="/bin/false")

    print(c.status)
```

With this change if the above parameters are provided then the container object is returned and the container removing (wait method is included) is started on a separated thread.

**Fix for:**

- https://github.com/containers/podman-py/issues/402
