### PR TITLE
Renovate: Update default assignment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,5 +51,5 @@
    *************************************************/
 
   // Don't leave dep. update. PRs "hanging", assign them to people.
-  "assignees": ["umohnani8", "cevich"],
+  "assignees": ["inknos"],
 }


### PR DESCRIPTION
@inknos PTAL.  Happy to change this to somebody(s) else if desired or remove the default assignment entirely.