### PR TITLE
Packit: enable c9s downstream update

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,6 +64,7 @@ jobs:
     packages: [python-podman-centos]
     dist_git_branches:
       - c10s
+      - c9s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
rpmautospec is now enabled on c9s envs so we should be ok to use the spec file maintained upstream for c9s as well.

Fixes: RUN-2123

@inknos PTAL