### PR TITLE
Packit: constrain koji and bodhi jobs to fedora package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -68,10 +68,12 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [python-podman-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
     trigger: commit
+    packages: [python-podman-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
This helps to avoid dup packit jobs during downstream updates.