### PR TITLE
Make black environment dependent on 3.12.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
     coverage report -m --skip-covered --fail-under=80 --omit=podman/tests/* --omit=.tox/*
 
 [testenv:black]
+depends = py3.12.6
 deps = black
 commands =
     black --diff --check .


### PR DESCRIPTION
Black complains with

Python 3.12.5 has a memory safety issue that can cause Black's AST safety checks to fail. Please upgrade to Python 3.12.6 or downgrade to Python 3.12.4

Let's fix the version for black until it's fixed