### PR TITLE
Accept integer ports in containers_create.create

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -174,7 +174,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             pids_limit (int): Tune a container's pids limit. Set -1 for unlimited.
             platform (str): Platform in the format os[/arch[/variant]]. Only used if the method
                 needs to pull the requested image.
-            ports (Dict[str, Union[int, Tuple[str, int], List[int], Dict[str, Union[int, Tuple[str, int], List[int]]]]]): Ports to bind inside the container.
+            ports (Dict[Union[int, str], Union[int, Tuple[str, int], List[int], Dict[str, Union[int, Tuple[str, int], List[int]]]]]): Ports to bind inside the container.
 
                 The keys of the dictionary are the ports to bind inside the container, either as an
                 integer or a string in the form port/protocol, where the protocol is either
@@ -622,6 +622,9 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             return result
 
         for container, host in args.pop("ports", {}).items():
+            if isinstance(container, int):
+                container = str(container)
+
             if "/" in container:
                 container_port, protocol = container.split("/")
             else:

--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -142,6 +142,16 @@ class ContainersIntegrationTest(base.IntegrationTest):
                     '1223/tcp': [{'HostIp': '', 'HostPort': '1235'}],
                 },
             },
+            {
+                'input': {
+                    2244: 3344,
+                },
+                'expected_output': {
+                    '2244/tcp': [
+                        {'HostIp': '', 'HostPort': '3344'},
+                    ],
+                },
+            },
         ]
 
         for port_test in port_tests:

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -43,7 +43,9 @@ class ContainersIntegrationTest(base.IntegrationTest):
 
         with self.subTest("Create from Alpine Image"):
             container = self.client.containers.create(
-                self.alpine_image, command=["echo", random_string], ports={'2222/tcp': 3333}
+                self.alpine_image,
+                command=["echo", random_string],
+                ports={'2222/tcp': 3333, 2244: 3344},
             )
             self.assertIsInstance(container, Container)
             self.assertGreater(len(container.attrs), 0)
@@ -62,6 +64,10 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.assertIn("2222/tcp", container.attrs["NetworkSettings"]["Ports"])
             self.assertEqual(
                 "3333", container.attrs["NetworkSettings"]["Ports"]["2222/tcp"][0]["HostPort"]
+            )
+            self.assertIn("2244/tcp", container.attrs["NetworkSettings"]["Ports"])
+            self.assertEqual(
+                "3344", container.attrs["NetworkSettings"]["Ports"]["2244/tcp"][0]["HostPort"]
             )
 
         file_contents = b"This is an integration test for archive."


### PR DESCRIPTION
Currently in containers_create.create(), the ports dict parameter is described as
    
> The keys of the dictionary are the ports to bind inside the container, either as an integer or a string in the form port/protocol
    
however, if the dict passed as this parameter has an integer as a key, it will result in a TypeError from the code on L625 `if "/" in container`.
    
Fix this by casting any integer keys to be strings beforehand.