### PR TITLE
Fix default stderr value of container.logs() to match documentation.

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -287,7 +287,7 @@ class Container(PodmanResource):
         params = {
             "follow": kwargs.get("follow", kwargs.get("stream", None)),
             "since": api.prepare_timestamp(kwargs.get("since")),
-            "stderr": kwargs.get("stderr", None),
+            "stderr": kwargs.get("stderr", True),
             "stdout": kwargs.get("stdout", True),
             "tail": kwargs.get("tail"),
             "timestamps": kwargs.get("timestamps"),


### PR DESCRIPTION
Fixes issue I reported in https://github.com/containers/podman-py/issues/451

> The docstring for container.logs states that the default value of the stderr keyword arg is True, when in fact if you look at the function code it defaults to None which is treated as False