### PR TITLE
[skip-ci] RPM: remove conditionals from changelog

### DIFF
--- a/rpm/python-podman.spec
+++ b/rpm/python-podman.spec
@@ -100,9 +100,4 @@ export PBR_VERSION="0.0.0"
 %doc README.md
 
 %changelog
-%if %{defined autochangelog}
 %autochangelog
-%else
-* Mon May 01 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>
-- Placeholder changelog for envs that are not autochangelog-ready
-%endif


### PR DESCRIPTION
All active Fedora and CentOS Stream environments support rpmautospec. So changelog conditionals can be removed.