### PR TITLE
Added support for mounting directories through the volume keyword.

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -16,6 +16,8 @@ from podman.errors import ImageNotFound
 
 logger = logging.getLogger("podman.containers")
 
+NAMED_VOLUME_PATTERN = re.compile(r'[a-zA-Z0-9][a-zA-Z0-9_.-]*')
+
 
 class CreateMixin:  # pylint: disable=too-few-public-methods
     """Class providing create method for ContainersManager."""
@@ -680,8 +682,21 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
                     raise ValueError("'mode' value should be a str")
                 options.append(mode)
 
-            volume = {"Name": key, "Dest": value["bind"], "Options": options}
-            params["volumes"].append(volume)
+            # The Podman API only supports named volumes through the ``volume`` parameter. Directory
+            # mounting needs to happen through the ``mounts`` parameter. Luckily the translation
+            # isn't too complicated so we can just do it for the user if we suspect that the key
+            # isn't a named volume.
+            if NAMED_VOLUME_PATTERN.match(key):
+                volume = {"Name": key, "Dest": value["bind"], "Options": options}
+                params["volumes"].append(volume)
+            else:
+                mount_point = {
+                    "destination": value['bind'],
+                    "options": options,
+                    "source": key,
+                    "type": 'bind',
+                }
+                params["mounts"].append(mount_point)
 
         for item in args.pop("secrets", []):
             if isinstance(item, Secret):


### PR DESCRIPTION
Fixes https://github.com/containers/podman-py/issues/151

The `volume` parameter when creating containers seems to be common cause of confusion and frustration when migrating from dockerpy to podmanpy. The docker API supports mounting directories through said parameter whereas podman wants users to use the `mounts` parameter despite what the documentation claims:

https://github.com/containers/podman-py/blob/7a674914edb15b2c3e657e74f0eca778a66eb9bc/podman/domain/containers_create.py#L304-L331

Currently, if a user tries to use the `volumes` keyword for directories they will get the following error:

`podman.errors.exceptions.APIError: 500 Server Error: Internal Server Error (error creating named volume "/home/user1/": error running volume create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument)`

I added support for directory mounting via `volumes` by checking if the key matches the provided pattern. If it does then the behavior doesn't change, if it doesn't then we translate the request into the equivalent mount specification.

This change differs slightly from the official API, but should minimize friction of people migrating and hopefully increase overall adoption.