### PR TITLE
Container.labels now returns an empty dict instead of None.

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -42,11 +42,15 @@ class Container(PodmanResource):
     @property
     def labels(self):
         """dict[str, str]: Returns labels associated with container."""
+        labels = None
         with suppress(KeyError):
+            # Container created from ``list()`` operation
             if "Labels" in self.attrs:
-                return self.attrs["Labels"]
-            return self.attrs["Config"]["Labels"]
-        return {}
+                labels = self.attrs["Labels"]
+            # Container created from ``get()`` operation
+            else:
+                labels = self.attrs["Config"].get("Labels", {})
+        return labels or {}
 
     @property
     def status(self):

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -56,6 +56,8 @@ class ContainersIntegrationTest(base.IntegrationTest):
 
         with self.subTest("Inspect Container"):
             actual = self.client.containers.get(container.id)
+
+            labeled_container.remove(v=True)
             self.assertIsInstance(actual, Container)
             self.assertEqual(actual.id, container.id)
 
@@ -188,6 +190,31 @@ ENV foo=bar
             self.assertEqual(len(container_list), len(existing_containers))
             volume_list = self.client.volumes.list()
             self.assertEqual(len(volume_list), len(existing_volumes))
+
+    def test_container_labels(self):
+        labels = {'label1': 'value1', 'label2': 'value2'}
+        labeled_container = self.client.containers.create(self.alpine_image, labels=labels)
+        unlabeled_container = self.client.containers.create(
+            self.alpine_image,
+        )
+
+        # inspect and list have 2 different schemas so we need to verify that we can
+        # successfully retrieve the labels on both
+        try:
+            # inspect schema
+            self.assertEqual(labeled_container.labels, labels)
+            self.assertEqual(unlabeled_container.labels, {})
+
+            # list schema
+            for container in self.client.containers.list(all=True):
+                if container.id == labeled_container.id:
+                    self.assertEqual(container.labels, labels)
+                elif container.id == unlabeled_container.id:
+                    self.assertEqual(container.labels, {})
+
+        finally:
+            labeled_container.remove(v=True)
+            unlabeled_container.remove(v=True)
 
 
 if __name__ == '__main__':

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -56,8 +56,6 @@ class ContainersIntegrationTest(base.IntegrationTest):
 
         with self.subTest("Inspect Container"):
             actual = self.client.containers.get(container.id)
-
-            labeled_container.remove(v=True)
             self.assertIsInstance(actual, Container)
             self.assertEqual(actual.id, container.id)
 


### PR DESCRIPTION
Fixes https://github.com/containers/podman-py/issues/461