### PR TITLE
Fix typos

### DIFF
--- a/podman/api/typing_extensions.py
+++ b/podman/api/typing_extensions.py
@@ -22,7 +22,7 @@ import sys
 
 # After PEP 560, internal typing API was substantially reworked.
 # This is especially important for Protocol class which uses internal APIs
-# quite extensivelly.
+# quite extensively.
 PEP_560 = sys.version_info[:3] >= (3, 7, 0)
 
 if PEP_560:
@@ -2097,7 +2097,7 @@ elif HAVE_ANNOTATED:
         return len(name) > 4 and name.startswith('__') and name.endswith('__')
 
     # Prior to Python 3.7 types did not have `copy_with`. A lot of the equality
-    # checks, argument expansion etc. are done on the _subs_tre. As a result we
+    # checks, argument expansion etc. are done on the _subs_tree. As a result we
     # can't provide a get_type_hints function that strips out annotations.
 
     class AnnotatedMeta(typing.GenericMeta):

--- a/podman/api/uds.py
+++ b/podman/api/uds.py
@@ -153,7 +153,7 @@ class UDSAdapter(HTTPAdapter):
 
         Examples:
             requests.Session.mount(
-                "http://", UDSAdapater("http+unix:///run/user/1000/podman/podman.sock"))
+                "http://", UDSAdapter("http+unix:///run/user/1000/podman/podman.sock"))
         """
         self.poolmanager: Optional[UDSPoolManager] = None
 

--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -176,7 +176,7 @@ class Container(PodmanResource):
             ``response_code``:
                 The exit code of the provided command. ``None`` if ``stream``.
             ``output``:
-                If ``stream``, then a generator yeilding response chunks.
+                If ``stream``, then a generator yielding response chunks.
                 If ``demux``, then a tuple of (``stdout``, ``stderr``).
                 Else the response content.
 

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -44,7 +44,7 @@ class ImagesIntegrationTest(base.IntegrationTest):
         """Test Image CRUD.
 
         Notes:
-            Written to maximize re-use of pulled image.
+            Written to maximize reuse of pulled image.
         """
 
         with self.subTest("Pull Alpine Image"):


### PR DESCRIPTION
Found via `codespell -H` and `typos --hidden --format brief`