### PR TITLE
fix: /run/user/ is based on UID not username

### DIFF
--- a/podman/api/path_utils.py
+++ b/podman/api/path_utils.py
@@ -17,7 +17,7 @@ def get_runtime_dir() -> str:
         return os.environ['XDG_RUNTIME_DIR']
     except KeyError:
         user = getpass.getuser()
-        run_user = f'/run/user/{user}'
+        run_user = f'/run/user/{os.getuid()}'
         if os.path.isdir(run_user):
             return run_user
         fallback = f'/tmp/podmanpy-runtime-dir-fallback-{user}'

--- a/podman/tests/unit/test_path_utils.py
+++ b/podman/tests/unit/test_path_utils.py
@@ -10,7 +10,6 @@ from podman import api
 class PathUtilsTestCase(unittest.TestCase):
     def setUp(self):
         self.xdg_runtime_dir = os.getenv('XDG_RUNTIME_DIR')
-        print('XDG_RUNTIME_DIR', self.xdg_runtime_dir)
 
     @mock.patch.dict(os.environ, clear=True)
     def test_get_runtime_dir_env_var_set(self):
@@ -18,9 +17,20 @@ class PathUtilsTestCase(unittest.TestCase):
             os.environ['XDG_RUNTIME_DIR'] = str(tmpdir)
             self.assertEqual(str(tmpdir), api.path_utils.get_runtime_dir())
 
-    @unittest.skipUnless(os.getenv('XDG_RUNTIME_DIR'), 'XDG_RUNTIME_DIR must be set')
     @mock.patch.dict(os.environ, clear=True)
     def test_get_runtime_dir_env_var_not_set(self):
+        if not self.xdg_runtime_dir:
+            self.skipTest('XDG_RUNTIME_DIR must be set for this test.')
+        if self.xdg_runtime_dir.startswith('/run/user/'):
+            self.skipTest("XDG_RUNTIME_DIR in /run/user/, can't check")
+        self.assertNotEqual(self.xdg_runtime_dir, api.path_utils.get_runtime_dir())
+
+    @mock.patch('os.path.isdir', lambda d: False)
+    @mock.patch.dict(os.environ, clear=True)
+    def test_get_runtime_dir_env_var_not_set_and_no_run(self):
+        """Fake that XDG_RUNTIME_DIR is not set and /run/user/ does not exist."""
+        if not self.xdg_runtime_dir:
+            self.skipTest('XDG_RUNTIME_DIR must be set to fetch a working dir.')
         self.assertNotEqual(self.xdg_runtime_dir, api.path_utils.get_runtime_dir())
 
 


### PR DESCRIPTION
I got one key detail wrong in #475: `/run/user` is based on UID not username. This fixes that and is better tested.