### PR TITLE
New CI Images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     ####
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c20241015t085508z-f40f39d13"
+    IMAGE_SUFFIX: "c20241212t122344z-f41f40d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-podman-py-${IMAGE_SUFFIX}"
 
 

--- a/contrib/cirrus/build_podman.sh
+++ b/contrib/cirrus/build_podman.sh
@@ -4,6 +4,6 @@ set -xeo pipefail
 
 systemctl stop podman.socket || :
 
-dnf erase podman -y
+dnf remove podman -y
 dnf copr enable rhcontainerbot/podman-next -y
 dnf install podman -y


### PR DESCRIPTION
build from https://github.com/containers/automation_images/pull/396

---

cirrus: replace dnf command

The new images updated to f41 and thus contain dnf5, dnf erase is no
longer valid so just call dnf remove to remove the package.