### PR TITLE
Implement "decode" parameter in pull()

### DIFF
--- a/podman/domain/json_stream.py
+++ b/podman/domain/json_stream.py
@@ -1,0 +1,74 @@
+import json
+import json.decoder
+
+from podman.errors import StreamParseError
+
+json_decoder = json.JSONDecoder()
+
+
+def stream_as_text(stream):
+    """
+    Given a stream of bytes or text, if any of the items in the stream
+    are bytes convert them to text.
+    This function can be removed once we return text streams
+    instead of byte streams.
+    """
+    for data in stream:
+        if not isinstance(data, str):
+            data = data.decode('utf-8', 'replace')
+        yield data
+
+
+def json_splitter(buffer):
+    """Attempt to parse a json object from a buffer. If there is at least one
+    object, return it and the rest of the buffer, otherwise return None.
+    """
+    buffer = buffer.strip()
+    try:
+        obj, index = json_decoder.raw_decode(buffer)
+        rest = buffer[json.decoder.WHITESPACE.match(buffer, index).end() :]
+        return obj, rest
+    except ValueError:
+        return None
+
+
+def json_stream(stream):
+    """Given a stream of text, return a stream of json objects.
+    This handles streams which are inconsistently buffered (some entries may
+    be newline delimited, and others are not).
+    """
+    return split_buffer(stream, json_splitter, json_decoder.decode)
+
+
+def line_splitter(buffer, separator='\n'):
+    index = buffer.find(str(separator))
+    if index == -1:
+        return None
+    return buffer[: index + 1], buffer[index + 1 :]
+
+
+def split_buffer(stream, splitter=None, decoder=lambda a: a):
+    """Given a generator which yields strings and a splitter function,
+    joins all input, splits on the separator and yields each chunk.
+    Unlike string.split(), each chunk includes the trailing
+    separator, except for the last one if none was found on the end
+    of the input.
+    """
+    splitter = splitter or line_splitter
+    buffered = ''
+
+    for data in stream_as_text(stream):
+        buffered += data
+        while True:
+            buffer_split = splitter(buffered)
+            if buffer_split is None:
+                break
+
+            item, buffered = buffer_split
+            yield item
+
+    if buffered:
+        try:
+            yield decoder(buffered)
+        except Exception as e:
+            raise StreamParseError(e) from e

--- a/podman/errors/__init__.py
+++ b/podman/errors/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     'NotFound',
     'NotFoundError',
     'PodmanError',
+    'StreamParseError',
 ]
 
 try:
@@ -32,6 +33,7 @@ try:
         InvalidArgument,
         NotFound,
         PodmanError,
+        StreamParseError,
     )
 except ImportError:
     pass

--- a/podman/errors/exceptions.py
+++ b/podman/errors/exceptions.py
@@ -142,3 +142,8 @@ class ContainerError(PodmanError):
 
 class InvalidArgument(PodmanError):
     """Parameter to method/function was not valid."""
+
+
+class StreamParseError(RuntimeError):
+    def __init__(self, reason):
+        self.msg = reason

--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -151,6 +151,10 @@ class ImagesIntegrationTest(base.IntegrationTest):
         generator = self.client.images.pull("ubi8", tag="latest", stream=True)
         self.assertIsInstance(generator, types.GeneratorType)
 
+    def test_pull_stream_decode(self):
+        generator = self.client.images.pull("ubi8", tag="latest", stream=True, decode=True)
+        self.assertIsInstance(generator, types.GeneratorType)
+
     def test_scp(self):
         with self.assertRaises(APIError) as e:
             next(


### PR DESCRIPTION
Implement `decode (bool)` parameter in `pull()`. Decode the JSON data from the server into dicts. Only applies with `stream=True`.

If `decode` is not implemented, the output will be something like:
```
b'{"stream":"Trying to pull docker.io/ohmyzsh/zsh:latest...\\n"}
...
```
By implementing `decode` the pull output will be:
```
{'stream': 'Trying to pull docker.io/ohmyzsh/zsh:latest...\n'}
```

It partial covers https://github.com/containers/podman-py/issues/456