### PR TITLE
Add support for container initialization

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -54,7 +54,7 @@ class Container(PodmanResource):
 
     @property
     def status(self):
-        """Literal["running", "stopped", "exited", "unknown"]: Returns status of container."""
+        """Literal["created", "initialized", "running", "stopped", "exited", "unknown"]: Returns status of container."""
         with suppress(KeyError):
             return self.attrs["State"]["Status"]
         return "unknown"
@@ -261,6 +261,11 @@ class Container(PodmanResource):
         stat = response.headers.get("x-docker-container-path-stat", None)
         stat = api.decode_header(stat)
         return response.iter_content(chunk_size=chunk_size), stat
+
+    def init(self) -> None:
+        """Initialize the container."""
+        response = self.client.post(f"/containers/{self.id}/init")
+        response.raise_for_status()
 
     def inspect(self) -> Dict:
         """Inspect a container.

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -143,6 +143,24 @@ class ContainersIntegrationTest(base.IntegrationTest):
             top_ctnr.reload()
             self.assertIn(top_ctnr.status, ("exited", "stopped"))
 
+        with self.subTest("Create-Init-Start Container"):
+            top_ctnr = self.client.containers.create(
+                self.alpine_image, ["/usr/bin/top"], name="TestInitPs", detach=True
+            )
+            self.assertEqual(top_ctnr.status, "created")
+
+            top_ctnr.init()
+            top_ctnr.reload()
+            self.assertEqual(top_ctnr.status, "initialized")
+
+            top_ctnr.start()
+            top_ctnr.reload()
+            self.assertEqual(top_ctnr.status, "running")
+
+            top_ctnr.stop()
+            top_ctnr.reload()
+            self.assertIn(top_ctnr.status, ("exited", "stopped"))
+
         with self.subTest("Prune Containers"):
             report = self.client.containers.prune()
             self.assertIn(top_ctnr.id, report["ContainersDeleted"])

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -102,6 +102,17 @@ class ContainersTestCase(unittest.TestCase):
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()
+    def test_init(self, mock):
+        adapter = mock.post(
+            tests.LIBPOD_URL
+            + "/containers/87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd/init",
+            status_code=204,
+        )
+        container = Container(attrs=FIRST_CONTAINER, client=self.client.api)
+        container.init()
+        self.assertTrue(adapter.called_once)
+
+    @requests_mock.Mocker()
     def test_stats(self, mock):
         stream = [
             {


### PR DESCRIPTION
In reference to my issue #490, I have drafted a patch to add support for the operation.

I have performed some trivial manual testing of the change, but trying to run `tox` results in the log line below repeating indefinitely, and as such I have not run the various testing facilities that the project provides.

If anyone would be able to help me to get the tests running, I would be more than happy to also contribute additional coverage for this new method.

```
------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------
2025-01-05 18:10:08 [    INFO] Launching(5.3.1) podman --log-level=info system service --time=0 unix:///tmp/tmpqcq78j4c/ad527583baab4ebb96975b65cda25702 refid=1483129501152721076 (utils.py:86)
2025-01-05 18:10:08 [   DEBUG] Starting new HTTP connection (1): localhost:22 (connectionpool.py:241)
2025-01-05 18:10:08 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:08 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:08 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:08 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:09 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:09 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
2025-01-05 18:10:09 [   DEBUG] Waiting on /run/user/1000/podman/podman-forward-4cad89234a116ac037aa.sock (ssh.py:89)
```