### PR TITLE
Implement compatMode raw JSON output and fix tls_verify init on pull()

### DIFF
--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -323,6 +323,8 @@ class ImagesManager(BuildMixin, Manager):
             auth_config (Mapping[str, str]) – Override the credentials that are found in the
                 config for this request. auth_config should contain the username and password
                 keys to be valid.
+            compatMode (bool) – Return the same JSON payload as the Docker-compat endpoint.
+                Default: True.
             platform (str) – Platform in the format os[/arch[/variant]]
             progress_bar (bool) - Display a progress bar with the image pull progress (uses
                 the compat endpoint). Default: False
@@ -354,7 +356,8 @@ class ImagesManager(BuildMixin, Manager):
 
         params = {
             "reference": repository,
-            "tlsVerify": kwargs.get("tls_verify"),
+            "tlsVerify": kwargs.get("tls_verify", True),
+            "compatMode": kwargs.get("compatMode", True),
         }
 
         if all_tags:


### PR DESCRIPTION
Fix https://github.com/containers/podman-py/issues/492

Added `compatMode` param to `pull()` function. Default as `True` in order to give a detailed progress JSON output by default like:
```
...
{'status': 'Pulling fs layer', 'progressDetail': {}, 'id': 'ef3afbc03436'}
{'status': 'Downloading', 'progressDetail': {'current': 1862903, 'total': 37308955}, 'progress': '[==>                                                ]  1.863MB/37.31MB', 'id': '1546de61b6c3'}
{'status': 'Download complete', 'progressDetail': {}, 'id': 'fa424c11eb04'}
{'status': 'Pulling fs layer', 'progressDetail': {}, 'id': '3d3d38ab8766'}
{'status': 'Downloading', 'progressDetail': {'current': 1441042, 'total': 3248294}, 'progress': '[======================>                            ]  1.441MB/3.248MB', 'id': 'ef3afbc03436'}
...
```
while `compatMode=False` still keeps the one-field `stream` JSON output:
```
{'stream': 'Copying blob sha256:30babffc8f090f7c78c263b9a1b683b34ca5f73da74911ffe942d4d8225dca57\n'}
```
This approach differs from the already present `progress_bar=True` because does not show the "fancy" progress bar but a raw detailed progressing JSON output, useful for devs want to manipulate pull output.

Furthermore, the PR fixes `tls_verify` initialization in `pull()` because, according to its description, its Default should be `True`, but it was actually as `None`.