### PR TITLE
fix: accept a string for the `command` argument of Container.start

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -344,6 +344,8 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
         """
         if isinstance(image, Image):
             image = image.id
+        if isinstance(command, str):
+            command = [command]
 
         payload = {"image": image, "command": command}
         payload.update(kwargs)


### PR DESCRIPTION
This makes its interface consistent with its own documentation, and with Container.run, by allowing both a list of arguments and a single string for the `command` parameter.