### PR TITLE
Clarify documentation of container removal flags

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -225,7 +225,6 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
             read_only (bool): Mount the container's root filesystem as read only.
             read_write_tmpfs (bool): Mount temporary file systems as read write,
                 in case of read_only options set to True. Default: False
-            remove (bool): Remove the container when it has finished running. Default: False.
             restart_policy (Dict[str, Union[str, int]]): Restart the container when it exits.
                 Configured as a dictionary with keys:
 

--- a/podman/domain/containers_run.py
+++ b/podman/domain/containers_run.py
@@ -30,14 +30,17 @@ class RunMixin:  # pylint: disable=too-few-public-methods
         By default, run() will wait for the container to finish and return its logs.
 
         If detach=True, run() will start the container and return a Container object rather
-            than logs.
+            than logs. In this case, if remove=True, run() will monitor and remove the
+            container after it finishes running; the logs will be lost in this case.
 
         Args:
             image: Image to run.
             command: Command to run in the container.
             stdout: Include stdout. Default: True.
             stderr: Include stderr. Default: False.
-            remove: Delete container when the container's processes exit. Default: False.
+            remove: Delete container on the client side when the container's processes exit.
+                The `auto_remove` flag is also available to manage the removal on the daemon
+                side. Default: False.
 
         Keyword Args:
             - See the create() method for keyword arguments.


### PR DESCRIPTION
This addresses the issue described in detail in #496, by updating the docstring for the `create()` and `run()` operations of Container.