### PR TITLE
Proof-of-concept: set up necessary idmappings for userns_mode=auto in Container.create()

### DIFF
--- a/podman/domain/containers_create.py
+++ b/podman/domain/containers_create.py
@@ -739,6 +739,33 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
         if "userns_mode" in args:
             params["userns"] = {"nsmode": args.pop("userns_mode")}
 
+            # proof-of-concept
+            def merge_dicts(d1, d2):
+                for dk in d2:
+                    if dk in d1:
+                        if not isinstance(d1[dk], dict) or not isinstance(d2[dk], dict):
+                            d1[dk] = d2[dk]
+                        else:
+                            d1[dk] = merge_dicts(d1[dk], d2[dk])
+                    else:
+                        d1[dk] = d2[dk]
+                return d1
+
+            default_idmappings = {
+                "AutoUserNs": False if params["userns"]["nsmode"] != "auto" else True,
+                "AutoUserNsOpts": None if params["userns"]["nsmode"] != "auto" else {
+                    "AdditionalUIDMappings": None,
+                    "AdditionalGIDMappings": None,
+                    "PasswdFile": "",
+                    "GroupFile": "",
+                    "InitialSize": 0,
+                    "Size": 0,
+                },
+            }
+
+            old_idmappings = params.get("idmappings") or {}
+            params.update(idmappings=merge_dicts(default_idmappings, old_idmappings))
+
         if "uts_mode" in args:
             params["utsns"] = {"nsmode": args.pop("uts_mode")}
 


### PR DESCRIPTION
This is a proof-of-concept commit to gather initial feedback.

This addresses the issue in #493, i.e., that passing `userns='auto'` to Container.create() results in the option being silently ignored.

Before this patch, `podman-py` used to set up the `userns` API parameter when the `userns` parameter was given to Container.create(). However, upon investigation, it seems like the Podman service silently ignores the passed `userns` if parameter `idmappings` is missing.

This patch addresses this behaviour by setting up `idmappings` with neutral values (i.e., the values resulting in the same behaviour as the Podman client when called with --userns=auto without more specific options), while specifically retaining any explicit values passed by the user using the undocumented argument `idmappings`.

I am looking for some feedback about this PR:
- Is the general structure of the solution acceptable?
- I do not see any other instances where a dict merge approach is used to set up default values. Is there perhaps a better place to put the `merge_dicts()` function? Or would it be better altogether to merge the relatively small structure manually and avoid adding that function altogether?
- I see that, in general, integration testing is pretty minimal and doesn't cover very many of the possible use cases of `podman-py`. In your view, what would be a good collection of integration tests for this PR/feature? At a minimum, I will be contributing one integration test which checks that passing the `userns='auto'` results in a container with a private user namespace, with IDs not overlapping with the initial namespace, as that is my use case

