### PR TITLE
Add **kwargs to Network.connect call

### DIFF
--- a/podman/domain/networks.py
+++ b/podman/domain/networks.py
@@ -111,6 +111,7 @@ class Network(PodmanResource):
             f"/networks/{self.name}/connect",
             data=json.dumps(data),
             headers={"Content-type": "application/json"},
+            **kwargs,
         )
         response.raise_for_status()
 


### PR DESCRIPTION
This and other methods don't pass **kwargs to requests
and therefore it is not possible to enable the compatible
endpoint.