### PR TITLE
Bump release to 5.4.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podman"
-dynamic = ["version"]
+# TODO: remove the line version = ... on podman-py > 5.4.0 releases
+# dynamic = ["version"]
+version = "5.4.0.1"
 description = "Bindings for Podman RESTful API"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -70,8 +72,9 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 where = ["."]
 include = ["podman*"]
 
-[tool.setuptools.dynamic]
-version = {attr = "podman.version.__version__"}
+# TODO: remove the line version = ... on podman-py > 5.4.0 releases
+# [tool.setuptools.dynamic]
+# version = {attr = "podman.version.__version__"}
 
 [tool.ruff]
 line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman
-version = 5.4.0
+version = 5.4.0.1
 author = Brent Baude, Jhon Honce, Urvashi Mohnani, Nicola Sella
 author_email = jhonce@redhat.com
 description = Bindings for Podman RESTful API


### PR DESCRIPTION
The podman pyproject.toml was updated to fix a packaging issue that prevented the `import podman.api` to work.

This caused an issue in the package versioning. Python-podman cannot be bumped to version 5.4.1 since it will try to use the libpod/v5.4.1/ endpoint which is not released yet. Python-podman uses the same versioning scheme and so the package need to add a fourth digi in the version scheme to be released on PyPI. This can be avoided in distribution packages with the option of a new release or a patch downstream, but on GitHub and PyPI this is the workaround.

Source for packaging Python software
https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers