### PR TITLE
fix: set return type for `ImagesManager.load()` to `Image`

### DIFF
--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -123,7 +123,7 @@ class ImagesManager(BuildMixin, Manager):
 
     def load(
         self, data: Optional[bytes] = None, file_path: Optional[os.PathLike] = None
-    ) -> Generator[bytes, None, None]:
+    ) -> Generator[Image, None, None]:
         """Restore an image previously saved.
 
         Args:
@@ -159,7 +159,7 @@ class ImagesManager(BuildMixin, Manager):
         )
         response.raise_for_status()  # Catch any errors before proceeding
 
-        def _generator(body: dict) -> Generator[bytes, None, None]:
+        def _generator(body: dict) -> Generator[Image, None, None]:
             # Iterate and yield images from response body
             for item in body["Names"]:
                 yield self.get(item)


### PR DESCRIPTION
IMO this was an oversight at:
- #434 

The PR (#434) changed the return type from `Generator[Image, None, None]` to `Generator[bytes, None, None]`

The generator was created with the return value from `get`. `get` returns an `Image`

https://github.com/containers/podman-py/blob/2a29132efab4a183580a30d9c18b9bdb61b5ab49/podman/domain/images_manager.py#L162-L168

https://github.com/containers/podman-py/blob/2a29132efab4a183580a30d9c18b9bdb61b5ab49/podman/domain/images_manager.py#L83
