### PR TITLE
Set verbose: true to debug twine uploads to PypI

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -122,3 +122,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip_existing: true
+          verbose: true


### PR DESCRIPTION
Sometimes push to Test PyPI fails with 404. It is necessary to add verbose to see what's happening.

Some examples:
https://github.com/containers/podman-py/actions/runs/13407882925/job/37451651001
https://github.com/containers/podman-py/actions/runs/13494294813/job/37698067450