### PR TITLE
skip tests when the test image is not available (e.g. 32-bit)

### DIFF
--- a/podman/tests/integration/test_images.py
+++ b/podman/tests/integration/test_images.py
@@ -15,6 +15,7 @@
 """Images integration tests."""
 
 import io
+import platform
 import tarfile
 import types
 import unittest
@@ -143,10 +144,12 @@ class ImagesIntegrationTest(base.IntegrationTest):
         self.assertIsNotNone(image)
         self.assertIsNotNone(image.id)
 
+    @unittest.skipIf(platform.architecture()[0] == "32bit", "no 32-bit image available")
     def test_pull_stream(self):
         generator = self.client.images.pull("ubi8", tag="latest", stream=True)
         self.assertIsInstance(generator, types.GeneratorType)
 
+    @unittest.skipIf(platform.architecture()[0] == "32bit", "no 32-bit image available")
     def test_pull_stream_decode(self):
         generator = self.client.images.pull("ubi8", tag="latest", stream=True, decode=True)
         self.assertIsInstance(generator, types.GeneratorType)


### PR DESCRIPTION
Debian and other distros still ship for 32-bit systems.  But some of the test images are not available for 32-bit archs:

* https://ci.debian.net/packages/p/python-podman/testing/armel/58665732/
* https://ci.debian.net/packages/p/python-podman/testing/armhf/58665757/
* https://ci.debian.net/packages/p/python-podman/testing/i386/58561143/