### PR TITLE
Set X-Registry-Auth header on manifest push and bump to new API

### DIFF
--- a/podman/api/__init__.py
+++ b/podman/api/__init__.py
@@ -3,7 +3,7 @@
 from podman.api.cached_property import cached_property
 from podman.api.client import APIClient
 from podman.api.api_versions import VERSION, COMPATIBLE_VERSION
-from podman.api.http_utils import prepare_body, prepare_filters
+from podman.api.http_utils import encode_auth_header, prepare_body, prepare_filters
 from podman.api.parse_utils import (
     decode_header,
     frames,
@@ -27,6 +27,7 @@ __all__ = [
     'cached_property',
     'create_tar',
     'decode_header',
+    'encode_auth_header',
     'frames',
     'parse_repository',
     'prepare_body',

--- a/podman/api/http_utils.py
+++ b/podman/api/http_utils.py
@@ -100,5 +100,5 @@ def _filter_values(mapping: Mapping[str, Any], recursion=False) -> dict[str, Any
     return canonical
 
 
-def encode_auth_header(auth_config: dict[str, str]) -> str:
+def encode_auth_header(auth_config: dict[str, str]) -> bytes:
     return base64.urlsafe_b64encode(json.dumps(auth_config).encode('utf-8'))

--- a/podman/domain/images_manager.py
+++ b/podman/domain/images_manager.py
@@ -13,7 +13,6 @@ import requests
 
 from podman import api
 from podman.api.parse_utils import parse_repository
-from podman.api.http_utils import encode_auth_header
 from podman.domain.images import Image
 from podman.domain.images_build import BuildMixin
 from podman.domain.json_stream import json_stream
@@ -264,7 +263,7 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+            "X-Registry-Auth": api.encode_auth_header(auth_config) if auth_config else ""
         }
 
         params = {
@@ -359,7 +358,7 @@ class ImagesManager(BuildMixin, Manager):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+            "X-Registry-Auth": api.encode_auth_header(auth_config) if auth_config else ""
         }
 
         params = {

--- a/podman/domain/manifests.py
+++ b/podman/domain/manifests.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from typing import Any, Optional, Union
 
 from podman import api
+from podman.api.http_utils import encode_auth_header
 from podman.domain.images import Image
 from podman.domain.manager import Manager, PodmanResource
 from podman.errors import ImageNotFound
@@ -97,6 +98,7 @@ class Manifest(PodmanResource):
         self,
         destination: str,
         all: Optional[bool] = None,  # pylint: disable=redefined-builtin
+        **kwargs,
     ) -> None:
         """Push a manifest list or image index to a registry.
 
@@ -104,15 +106,32 @@ class Manifest(PodmanResource):
             destination: Target for push.
             all: Push all images.
 
+        Keyword Args:
+            auth_config (Mapping[str, str]: Override configured credentials. Must include
+                username and password keys.
+
         Raises:
             NotFound: when the Manifest could not be found
             APIError: when service reports an error
         """
+        auth_config: Optional[dict[str, str]] = kwargs.get("auth_config")
+
+        headers = {
+            # A base64url-encoded auth configuration
+            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+        }
+
         params = {
             "all": all,
             "destination": destination,
         }
-        response = self.client.post(f"/manifests/{self.quoted_name}/push", params=params)
+
+        destination_quoted = urllib.parse.quote_plus(destination)
+        response = self.client.post(
+            f"/manifests/{self.quoted_name}/registry/{destination_quoted}",
+            params=params,
+            headers=headers,
+        )
         response.raise_for_status()
 
     def remove(self, digest: str) -> None:

--- a/podman/domain/manifests.py
+++ b/podman/domain/manifests.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 from typing import Any, Optional, Union
 
 from podman import api
-from podman.api.http_utils import encode_auth_header
 from podman.domain.images import Image
 from podman.domain.manager import Manager, PodmanResource
 from podman.errors import ImageNotFound
@@ -118,7 +117,7 @@ class Manifest(PodmanResource):
 
         headers = {
             # A base64url-encoded auth configuration
-            "X-Registry-Auth": encode_auth_header(auth_config) if auth_config else ""
+            "X-Registry-Auth": api.encode_auth_header(auth_config) if auth_config else ""
         }
 
         params = {

--- a/podman/tests/unit/test_api_utils.py
+++ b/podman/tests/unit/test_api_utils.py
@@ -164,6 +164,15 @@ class TestUtilsCase(unittest.TestCase):
 
         self.assertDictEqual(payload, actual_dict)
 
+    def test_encode_auth_header(self):
+        auth_config = {
+            "username": "user",
+            "password": "pass",
+        }
+        expected = b"eyJ1c2VybmFtZSI6ICJ1c2VyIiwgInBhc3N3b3JkIjogInBhc3MifQ=="
+        actual = api.encode_auth_header(auth_config)
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -181,7 +181,7 @@ class ImagesManagerTestCase(unittest.TestCase):
         """Unit test filters param for Images prune()."""
         mock.post(
             tests.LIBPOD_URL + "/images/prune?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
-            params=[
+            json=[
                 {
                     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
                     "Size": 1024,

--- a/podman/tests/unit/test_imagesmanager.py
+++ b/podman/tests/unit/test_imagesmanager.py
@@ -181,7 +181,7 @@ class ImagesManagerTestCase(unittest.TestCase):
         """Unit test filters param for Images prune()."""
         mock.post(
             tests.LIBPOD_URL + "/images/prune?filters=%7B%22dangling%22%3A+%5B%22True%22%5D%7D",
-            json=[
+            params=[
                 {
                     "Id": "326dd9d7add24646a325e8eaa82125294027db2332e49c5828d96312c5d773ab",
                     "Size": 1024,

--- a/podman/tests/unit/test_manifests.py
+++ b/podman/tests/unit/test_manifests.py
@@ -1,7 +1,14 @@
 import unittest
 
+import requests_mock
+
 from podman import PodmanClient, tests
 from podman.domain.manifests import Manifest, ManifestsManager
+
+FIRST_MANIFEST = {
+    "Id": "326dd9d7add24646a389e8eaa82125294027db2332e49c5828d96312c5d773ab",
+    "names": "quay.io/fedora:latest",
+}
 
 
 class ManifestTestCase(unittest.TestCase):
@@ -22,6 +29,34 @@ class ManifestTestCase(unittest.TestCase):
     def test_name(self):
         manifest = Manifest()
         self.assertIsNone(manifest.name)
+
+    @requests_mock.Mocker()
+    def test_push(self, mock):
+        adapter = mock.post(
+            tests.LIBPOD_URL + "/manifests/quay.io%2Ffedora%3Alatest/registry/quay.io%2Ffedora%3Av1"
+        )
+
+        manifest = Manifest(attrs=FIRST_MANIFEST, client=self.client.api)
+        manifest.push(destination="quay.io/fedora:v1")
+
+        self.assertTrue(adapter.called_once)
+
+    @requests_mock.Mocker()
+    def test_push_with_auth(self, mock):
+        adapter = mock.post(
+            tests.LIBPOD_URL
+            + "/manifests/quay.io%2Ffedora%3Alatest/registry/quay.io%2Ffedora%3Av1",
+            request_headers={
+                "X-Registry-Auth": b"eyJ1c2VybmFtZSI6ICJ1c2VyIiwgInBhc3N3b3JkIjogInBhc3MifQ=="
+            },
+        )
+
+        manifest = Manifest(attrs=FIRST_MANIFEST, client=self.client.api)
+        manifest.push(
+            destination="quay.io/fedora:v1", auth_config={"username": "user", "password": "pass"}
+        )
+
+        self.assertTrue(adapter.called_once)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Allows the setting of an authentication header similar to the push of images (related to #164)
- The current api to push manifests has been deprecated since podman 4.0 ([`http://podman.io/libpod/manifests/{name}/push`](https://docs.podman.io/en/latest/_static/api.html#tag/manifests/operation/ManifestPushV3Libpod))
- Use the "new" API: [`http://podman.io/libpod/manifests/{name}/registry/{destination}`](https://docs.podman.io/en/latest/_static/api.html#tag/manifests/operation/ManifestPushLibpod)

I was already unable to use the old API with Podman 4.9

The current implementation for image push:

https://github.com/containers/podman-py/blob/a75e8c2b848d4f48af6f72c3170b5aa02bdff092/podman/domain/images_manager.py#L241-L268