### PR TITLE
Fix: fix timeout tipe as int

### DIFF
--- a/podman/domain/pods.py
+++ b/podman/domain/pods.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Union
 
 from podman.domain.manager import PodmanResource
 
-_Timeout = Union[None, float, tuple[float, float], tuple[float, None]]
+_Timeout = Union[None, int, tuple[int, int], tuple[int, None]]
 
 logger = logging.getLogger("podman.pods")
 

--- a/podman/tests/unit/test_pod.py
+++ b/podman/tests/unit/test_pod.py
@@ -149,7 +149,7 @@ class PodTestCase(unittest.TestCase):
     def test_stop(self, mock):
         adapter = mock.post(
             tests.LIBPOD_URL
-            + "/pods/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/stop?t=70.0",
+            + "/pods/c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8/stop?t=70",
             json={
                 "Errs": [],
                 "Id": "c8b9f5b17dc1406194010c752fc6dcb330192032e27648db9b14060447ecf3b8",
@@ -157,7 +157,7 @@ class PodTestCase(unittest.TestCase):
         )
 
         pod = Pod(attrs=FIRST_POD, client=self.client.api)
-        pod.stop(timeout=70.0)
+        pod.stop(timeout=70)
         self.assertTrue(adapter.called_once)
 
     @requests_mock.Mocker()


### PR DESCRIPTION
Documentation and Annotations require timeout to be a float, but the API requires an integer.

@jwhonce do you know why the type was annotated as `Union[None, float, tuple[float, float], tuple[float, None]]` and not just `Union[None, float]`? Was that an historical reason?