### PR TITLE
Bump release to 5.5.0 and enable updates-testing repos on Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-main} HEAD)
 HEAD ?= HEAD
 
-export PODMAN_VERSION ?= "5.4.0"
+export PODMAN_VERSION ?= "5.5.0"
 
 .PHONY: podman
 podman:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -51,6 +51,14 @@ prepare:
 
 # Run tests against Podman buids installed from the distribution.
 /distro:
+    prepare+:
+      - name: Enable testing repositories
+        when: initiator == packit && distro == fedora
+        how: shell
+        script: |
+          dnf config-manager setopt updates-testing.enabled=true
+          dnf -y upgrade --allowerasing --setopt=allow_vendor_change=true
+
     /sanity:
         summary: Run Sanity and Coverage checks on Python Podman
         discover+:

--- a/podman/tests/__init__.py
+++ b/podman/tests/__init__.py
@@ -3,5 +3,5 @@
 # Do not auto-update these from version.py,
 #   as test code should be changed to reflect changes in Podman API versions
 BASE_SOCK = "unix:///run/api.sock"
-LIBPOD_URL = "http://%2Frun%2Fapi.sock/v5.4.0/libpod"
+LIBPOD_URL = "http://%2Frun%2Fapi.sock/v5.5.0/libpod"
 COMPATIBLE_URL = "http://%2Frun%2Fapi.sock/v1.40"

--- a/podman/version.py
+++ b/podman/version.py
@@ -1,4 +1,4 @@
 """Version of PodmanPy."""
 
-__version__ = "5.4.0"
+__version__ = "5.5.0"
 __compatible_version__ = "1.40"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = podman
-version = 5.4.0.1
+version = 5.5.0
 author = Brent Baude, Jhon Honce, Urvashi Mohnani, Nicola Sella
 author_email = jhonce@redhat.com
 description = Bindings for Podman RESTful API


### PR DESCRIPTION
This PR should enable testing on updates-latest, so we can test on 5.5.0 binaries before they get stable karma