### PR TITLE
Don't try to parse the response json when not_modified

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -472,6 +472,10 @@ class Container(PodmanResource):
         if response.status_code == requests.codes.not_modified:
             if kwargs.get("ignore", False):
                 return
+            else:
+                raise APIError(
+                    response.text, response=response, explanation="Container already stopped."
+                )
 
         body = response.json()
         raise APIError(body["cause"], response=response, explanation=body["message"])

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -142,7 +142,8 @@ class ContainersIntegrationTest(base.IntegrationTest):
 
             # Try stopping the already stopped.
             # See https://github.com/containers/podman-py/pull/550 for more info.
-            top_ctnr.stop()
+            with self.assertRaises(APIError):
+                top_ctnr.stop()
 
             top_ctnr.reload()
             self.assertIn(top_ctnr.status, ("exited", "stopped"))

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -15,7 +15,7 @@ import podman.tests.integration.base as base
 from podman import PodmanClient
 from podman.domain.containers import Container
 from podman.domain.images import Image
-from podman.errors import NotFound
+from podman.errors import NotFound, APIError
 
 # @unittest.skipIf(os.geteuid() != 0, 'Skipping, not running as root')
 

--- a/podman/tests/integration/test_containers.py
+++ b/podman/tests/integration/test_containers.py
@@ -139,6 +139,11 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.assertIn("/usr/bin/top", report["Processes"][0][-1])
 
             top_ctnr.stop()
+
+            # Try stopping the already stopped.
+            # See https://github.com/containers/podman-py/pull/550 for more info.
+            top_ctnr.stop()
+
             top_ctnr.reload()
             self.assertIn(top_ctnr.status, ("exited", "stopped"))
 


### PR DESCRIPTION
In case of not_modified (HTTP 304), there is no json in the response
body. Json parsing fails like:
```python
        if response.status_code == requests.codes.not_modified:
            if kwargs.get("ignore", False):
                return

        body = response
>       raise APIError(body["cause"], response=response, explanation=body)
E       TypeError: 'APIResponse' object is not subscriptable

.venv/lib/python3.12/site-packages/podman/domain/containers.py:477: TypeError
```
This patch fixes this in the way that APIError is rised with content
from the text of the requests response
