### PR TITLE
fix image build not using cache

### DIFF
--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -204,8 +204,16 @@ class BuildMixin:
         if "labels" in kwargs:
             params["labels"] = json.dumps(kwargs.get("labels"))
 
-        if params["dockerfile"] is None:
-            params["dockerfile"] = f".containerfile.{random.getrandbits(160):x}"
+        def default(value, def_value):
+            return def_value if value is None else value
+
+        params["outputformat"] = default(
+            params["outputformat"], "application/vnd.oci.image.manifest.v1+json"
+        )
+        params["layers"] = default(params["layers"], True)
+        params["dockerfile"] = default(
+            params["dockerfile"], f".containerfile.{random.getrandbits(160):x}"
+        )
 
         # Remove any unset parameters
         return dict(filter(lambda i: i[1] is not None, params.items()))


### PR DESCRIPTION
This commit fixes issue #528 by adding a default value to parameters layers and outputformat. This change aligns the behavior with podman-remote.

@inknos take a look, I've also added a test for this PR