### PR TITLE
fix: broken configuration for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,10 +21,10 @@ build:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    method: pip
-    path: .
-    extra_requirements:
-      - docs
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Part of:
- #532 

Follow up to:
- #546 

Docs and example: https://docs.readthedocs.com/platform/stable/config-file/v2.html#packages

Current failure: https://app.readthedocs.org/projects/podman-py/builds/28555767/

```
Config file validation error Config validation error in python.install. Expected a list, got type dict ({'path': '.', 'method': 'pip', 'extra_requirements': ['docs']}).
```