### PR TITLE
tests: Fix tests to reflect removal of rw as default option

### DIFF
--- a/podman/tests/integration/test_container_create.py
+++ b/podman/tests/integration/test_container_create.py
@@ -316,7 +316,7 @@ class ContainersIntegrationTest(base.IntegrationTest):
             self.containers.append(container)
             self.assertEqual(
                 container.attrs.get('HostConfig', {}).get('Tmpfs', {}).get(mount['target']),
-                f"size={mount['size']},rw,rprivate,nosuid,nodev,tmpcopyup",
+                f"size={mount['size']},rprivate,nosuid,nodev,tmpcopyup",
             )
 
             container.start()


### PR DESCRIPTION
Behaviour changed upstream with https://github.com/containers/podman/pull/25942

Verification run: https://openqa.opensuse.org/tests/5261848

Fixes:

```
# Test messages # test_container_mounts
# failure: 

AssertionError: 'size=456k,rprivate,nosuid,nodev,tmpcopyup' != 'size=456k,rw,rprivate,nosuid,nodev,tmpcopyup'
- size=456k,rprivate,nosuid,nodev,tmpcopyup
+ size=456k,rw,rprivate,nosuid,nodev,tmpcopyup
?          +++
self = <podman.tests.integration.test_container_create.ContainersIntegrationTest testMethod=test_container_mounts>

    def test_container_mounts(self):
        """Test passing mounts"""
        with self.subTest("Check bind mount"):
            mount = {
                "type": "bind",
                "source": "/etc/hosts",
                "target": "/test",
                "read_only": True,
                "relabel": "Z",
            }
            container = self.client.containers.create(
                self.alpine_image, command=["cat", "/test"], mounts=[mount]
            )
            self.containers.append(container)
            self.assertIn(
                f"{mount['source']}:{mount['target']}:ro,Z,rprivate,rbind",
                container.attrs.get('HostConfig', {}).get('Binds', list()),
            )
    
            # check if container can be started and exits with EC == 0
            container.start()
            container.wait()
    
            self.assertEqual(container.attrs.get('State', dict()).get('ExitCode', 256), 0)
    
        with self.subTest("Check tmpfs mount"):
            mount = {"type": "tmpfs", "source": "tmpfs", "target": "/test", "size": "456k"}
            container = self.client.containers.create(
                self.alpine_image, command=["df", "-h"], mounts=[mount]
            )
            self.containers.append(container)
>           self.assertEqual(
                container.attrs.get('HostConfig', {}).get('Tmpfs', {}).get(mount['target']),
                f"size={mount['size']},rw,rprivate,nosuid,nodev,tmpcopyup",
            )
E           AssertionError: 'size=456k,rprivate,nosuid,nodev,tmpcopyup' != 'size=456k,rw,rprivate,nosuid,nodev,tmpcopyup'
E           - size=456k,rprivate,nosuid,nodev,tmpcopyup
E           + size=456k,rw,rprivate,nosuid,nodev,tmpcopyup
E           ?          +++

podman/tests/integration/test_container_create.py:274: AssertionError
```