### PR TITLE
Include test files in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include podman/tests *.py *.md
+include tox.ini


### PR DESCRIPTION
Include the test files and `tox.ini` in the source distribution to facilitate downstream testing.

Fixes #585