### PR TITLE
network.id should look for attrs "Id" and "id"...

### DIFF
--- a/podman/domain/networks.py
+++ b/podman/domain/networks.py
@@ -30,8 +30,11 @@ class Network(PodmanResource):
     @property
     def id(self):  # pylint: disable=invalid-name
         """str: Returns the identifier of the network."""
-        with suppress(KeyError):
+        if "Id" in self.attrs:
             return self.attrs["Id"]
+
+        if "id" in self.attrs:
+            return self.attrs["id"]
 
         with suppress(KeyError):
             sha256 = hashlib.sha256(self.attrs["name"].encode("ascii"))

--- a/podman/tests/integration/test_networks.py
+++ b/podman/tests/integration/test_networks.py
@@ -64,6 +64,13 @@ class NetworksIntegrationTest(base.IntegrationTest):
             names = [i.name for i in nets]
             self.assertIn("integration_test", names)
 
+        with self.subTest("Get by ID"):
+            network = self.client.networks.get("integration_test")
+            net_id = network.id
+            assert isinstance(net_id, str)
+            network_by_id = self.client.networks.get(net_id)
+            self.assertEqual(network.name, network_by_id.name)
+
         with self.subTest("Delete network"):
             network = self.client.networks.get("integration_test")
             network.remove(force=True)


### PR DESCRIPTION
...before falling back to a synthetic id based on the hash of the network name.

Checking both is needed to support the Docker-compatible format ("Id") and Libpod-native format ("id").

This is analagous to how podman-py handles network.name -- we check attrs "Name" and "name" in that order.

Fixes #584