### PR TITLE
Inknos update publish to pypy steps

### DIFF
--- a/.github/actions/build-python-package/action.yml
+++ b/.github/actions/build-python-package/action.yml
@@ -1,0 +1,54 @@
+name: 'Build Python Package'
+description: 'Build Python distribution packages (wheel and source tarball)'
+inputs:
+  python-version:
+    description: 'Python version to use for building'
+    required: false
+    default: '3.x'
+  upload-artifact:
+    description: 'Whether to upload the built packages as artifacts'
+    required: false
+    default: 'false'
+  artifact-name:
+    description: 'Name for the uploaded artifact'
+    required: false
+    default: 'python-package-distributions'
+  build-backend:
+    description: 'Build backend to use (build, hatch, etc.)'
+    required: false
+    default: 'build'
+
+outputs:
+  dist-path:
+    description: 'Path to the built distribution packages'
+    value: 'dist/'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install build backend
+      shell: bash
+      run: |
+        python3 -m pip install ${{ inputs.build-backend }} --user
+
+    - name: Build distribution packages
+      shell: bash
+      run: |
+        python3 -m build
+
+    - name: Upload distribution packages
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Test Build Python distribution 📦
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test Build Python distribution 📦
+    runs-on: ubuntu-latest
+    environment:
+      name: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build Python package
+        uses: ./.github/actions/build-python-package

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,9 @@
-name: Publish Python 🐍 distribution 📦 to TestPyPI
+name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+\.?[0-9]?'
 
 jobs:
   build:
@@ -17,18 +17,17 @@ jobs:
         uses: ./.github/actions/build-python-package
         with:
           upload-artifact: true
-          artifact-name: python-package-distributions-testpypi
+          artifact-name: python-package-distributions-pypi
 
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
     if: ${{ github.repository == 'containers/podman-py' }}
     needs: build
     runs-on: ubuntu-latest
-
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/podman
-
+      name: pypi
+      url: https://pypi.org/p/podman
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
 
@@ -36,11 +35,7 @@ jobs:
       - name: Download artifacts from build job
         uses: actions/download-artifact@v5
         with:
-          name: python-package-distributions-testpypi
+          name: python-package-distributions-pypi
           path: dist/
-      - name: Publish distribution 📦 to TestPyPI
+      - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          verbose: true

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -12,11 +12,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-
       - name: Install pypa/build
         run: >-
           python3 -m
@@ -53,54 +54,9 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    if: github.repository == 'containers/podman-py'
-    needs:
-      - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write # IMPORTANT: mandatory for sigstore
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v5
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.1
-        with:
-          inputs: >-
-            ./dist/*.tar.gz
-            ./dist/*.whl
-
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          '${{ github.ref_name }}'
-          --repo '${{ github.repository }}'
-          --generate-notes
-      - name: Upload artifact signatures to GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        # Upload to GitHub Release using the `gh` CLI.
-        # `dist/` contains the built packages, and the
-        # sigstore-produced signatures and certificates.
-        run: >-
-          gh release upload
-          '${{ github.ref_name }}' dist/**
-          --repo '${{ github.repository }}'
-
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: github.repository == 'containers/podman-py'
+    if: startsWith(github.ref, 'refs/heads/main') && github.repository == 'containers/podman-py'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -122,5 +78,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip_existing: true
+          skip-existing: true
           verbose: true


### PR DESCRIPTION
The step to create GH release is clunky, confusing, and fails most of the time. The code was supposed to be triggered on a new tag, but it's simpler to create a release from the GH dashboard and let it create the tag as well, which triggers pypi.

In the first commit, the workflow mirrors the one from packaging.python.org page but with few differences:

    "if" condition in publish-to-test-pypi, to run on main branch only
    skip-existing test.pypi releases is true to try and reduce the pypi usage

https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow

---

In the second commit, the build steps are split in an action and three separate workflows that should
- build on every PR (and don't upload artifacts as default)
- build and push to test pypi on every merge to main
- build and push to pypi on every tag push

Updates https://github.com/containers/podman-py/pull/583