### PR TITLE
Add direct support to `--manifest` when building container images.

### DIFF
--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -66,6 +66,8 @@ class BuildMixin:
             layers (bool) - Cache intermediate layers during build.
             output (str) - specifies if any custom build output is selected for following build.
             outputformat (str) - The format of the output image's manifest and configuration data.
+            manifest (str) - add the image to the specified manifest list.
+                Creates manifest list if it does not exist.
 
         Returns:
             first item is the podman.domain.images.Image built
@@ -173,6 +175,7 @@ class BuildMixin:
             "forcerm": kwargs.get("forcerm"),
             "httpproxy": kwargs.get("http_proxy"),
             "networkmode": kwargs.get("network_mode"),
+            "manifest": kwargs.get("manifest"),
             "nocache": kwargs.get("nocache"),
             "platform": kwargs.get("platform"),
             "pull": kwargs.get("pull"),

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -66,7 +66,8 @@ class TestBuildCase(unittest.TestCase):
                 "&buildargs=%7B%22BUILD_DATE%22%3A+%22January+1%2C+1970%22%7D"
                 "&cpuperiod=10"
                 "&extrahosts=%7B%22database%22%3A+%22127.0.0.1%22%7D"
-                "&labels=%7B%22Unittest%22%3A+%22true%22%7D",
+                "&labels=%7B%22Unittest%22%3A+%22true%22%7D"
+                "&manifest=example%3Av1.2.3",
                 text=buffer.getvalue(),
             )
             mock.get(
@@ -98,6 +99,7 @@ class TestBuildCase(unittest.TestCase):
                 },
                 extra_hosts={"database": "127.0.0.1"},
                 labels={"Unittest": "true"},
+                manifest="example:v1.2.3",
             )
             self.assertIsInstance(image, Image)
             self.assertEqual(image.id, "032b8b2855fc")


### PR DESCRIPTION
**Closes #592.**

With the proposed changes it is now possible to create manifests and automatically add images to them _as part of the build process_ (equivalent to `podman build --manifest ...`). 

```python
# ...
with PodmanClient(base_url=uri) as client:
  image, _ = client.images.build(
    path=".",
    dockerfile="Containerfile",
    manifest="example:v1.2.3",  # <-- this field is now supported 
    platform=["linux/amd64", "linux/arm64"],
  )
```

Running the previous code, all built images are automatically added to the provided manifest (which is also created if it does not exist already).

#### **Changes**:
- Mapped the `--manifest` argument into the expected `manifest` query parameter when making requests;
- Updated documentation for the `client.images.build` function as to refer to the newly support field. Description text extracted from the Podman CLI itself;
- Updated existing unit tests to ensure that `--manifest` argument is mapped into the expected query parameter;
- Implemented new integration test to ensure that a manifest is automatically created if required. A complementary cleanup mechanism was also implemented to ensure that manifests created during tests are deleted after their execution.

Looking forward to your feedback.