### PR TITLE
fix: use active service connection when no explicit connection specified

### DIFF
--- a/podman/domain/config.py
+++ b/podman/domain/config.py
@@ -59,6 +59,11 @@ class ServiceConnection:
             return Path(self.attrs.get("identity"))
         return Path(self.attrs.get("Identity"))
 
+    @cached_property
+    def is_machine(self) -> bool:
+        """bool: Returns True if connection is to a Podman machine."""
+        return self.attrs.get("IsMachine", False)
+
 
 class PodmanConfig:
     """PodmanConfig provides a representation of the containers.conf file."""


### PR DESCRIPTION
- Check for configured active service before falling back to local socket
- Fixes connection issues on macOS with podman machine setups

Fixes: https://github.com/containers/podman-py/issues/595