### PR TITLE
Add support to `--secrets` when building container images

### DIFF
--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -68,6 +68,7 @@ class BuildMixin:
             outputformat (str) - The format of the output image's manifest and configuration data.
             manifest (str) - add the image to the specified manifest list.
                 Creates manifest list if it does not exist.
+            secrets (list[str]) - Secret files/envs to expose to the build
 
         Returns:
             first item is the podman.domain.images.Image built
@@ -208,6 +209,9 @@ class BuildMixin:
             params["extrahosts"] = json.dumps(kwargs.get("extra_hosts"))
         if "labels" in kwargs:
             params["labels"] = json.dumps(kwargs.get("labels"))
+
+        if "secrets" in kwargs:
+            params["secrets"] = json.dumps(kwargs.get("secrets"))
 
         if params["dockerfile"] is None:
             params["dockerfile"] = f".containerfile.{random.getrandbits(160):x}"

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -67,7 +67,8 @@ class TestBuildCase(unittest.TestCase):
                 "&cpuperiod=10"
                 "&extrahosts=%7B%22database%22%3A+%22127.0.0.1%22%7D"
                 "&labels=%7B%22Unittest%22%3A+%22true%22%7D"
-                "&manifest=example%3Av1.2.3",
+                "&manifest=example%3Av1.2.3"
+                "&secrets=%5B%22id%3Dexample%2Csrc%3Dpodman-build-secret123%22%5D",
                 text=buffer.getvalue(),
             )
             mock.get(
@@ -100,6 +101,7 @@ class TestBuildCase(unittest.TestCase):
                 extra_hosts={"database": "127.0.0.1"},
                 labels={"Unittest": "true"},
                 manifest="example:v1.2.3",
+                secrets=["id=example,src=podman-build-secret123"],
             )
             self.assertIsInstance(image, Image)
             self.assertEqual(image.id, "032b8b2855fc")


### PR DESCRIPTION
**Closes #526**.

With the proposed changes it is now possible to pass secrets into the build context in a way that they won't be stored in the final image (equivalent to `podman build --secret ...`). They are temporarily mounted during the build process, in Containerfile `RUN --mount=type=secret,id=<some_id>` instructions, where the `<some_id>` matches the id specified in the corresponding `--secret` option of the `podman build` command.

**Changes:**
- Mapped the `--secrets` argument into the expected manifest query parameter when making requests;
- Updated documentation for the `client.images.build` function to include the added field. Description text extracted from the Podman CLI itself (with some additional info about the possibility of passing env variables)
- Updated existing unit tests to ensure that `--secret` argument is mapped into the expected query parameter;
- Implemented new integration test to ensure that a secret file is correctly passed and used by the build context, as well as testing that the file does not remain in the built image;
