### PR TITLE
(issue #604) Remove dependency on python_version<3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 # ~= with version numbers
 dependencies = [
     "requests >=2.24",
-    "tomli>=1.2.3; python_version<'3.11'",
+    "tomli>=1.2.3",
     "urllib3",
 ]
 


### PR DESCRIPTION
This PR aims to solve issue #604. 

I simply removed the dependency on `python_version<'3.11'` from the `dependencies` list. I determined that there was no need to change the minimum required version of `tomli`, due to `tomli` version 1.2.3 supporting any Python version greater or equal to 3.6. [Here](https://github.com/hukkin/tomli/blob/1.2.3/pyproject.toml) is a link to the `pyproject.toml` file for `tomli` version 1.2.3.