### PR TITLE
Add ssh parameter support for image builds

### DIFF
--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -70,6 +70,7 @@ class BuildMixin:
             manifest (str) - add the image to the specified manifest list.
                 Creates manifest list if it does not exist.
             secrets (list[str]) - Secret files/envs to expose to the build
+            ssh (list[str]) - SSH agent socket or keys to expose to the build
 
         Returns:
             first item is the podman.domain.images.Image built
@@ -215,6 +216,9 @@ class BuildMixin:
 
         if "secrets" in kwargs:
             params["secrets"] = json.dumps(kwargs.get("secrets"))
+
+        if "ssh" in kwargs:
+            params["ssh"] = json.dumps(kwargs.get("ssh"))
 
         # Remove any unset parameters
         return dict(filter(lambda i: i[1] is not None, params.items()))

--- a/podman/domain/images_build.py
+++ b/podman/domain/images_build.py
@@ -70,6 +70,9 @@ class BuildMixin:
             manifest (str) - add the image to the specified manifest list.
                 Creates manifest list if it does not exist.
             secrets (list[str]) - Secret files/envs to expose to the build
+            ssh (list[str]) - SSH agent socket or keys to expose to the build.
+                Format is the same as ``podman build --ssh``, e.g.
+                ``["default"]`` or ``["src=/path/to/key"]``.
 
         Returns:
             first item is the podman.domain.images.Image built
@@ -215,6 +218,9 @@ class BuildMixin:
 
         if "secrets" in kwargs:
             params["secrets"] = json.dumps(kwargs.get("secrets"))
+
+        if "ssh" in kwargs and kwargs.get("ssh") != []:
+            params["ssh"] = json.dumps(kwargs["ssh"])
 
         # Remove any unset parameters
         return dict(filter(lambda i: i[1] is not None, params.items()))

--- a/podman/tests/unit/test_build.py
+++ b/podman/tests/unit/test_build.py
@@ -1,7 +1,8 @@
 import io
-import requests
 import json
 import unittest
+
+import requests
 
 try:
     # Python >= 3.10
@@ -71,7 +72,8 @@ class TestBuildCase(unittest.TestCase):
                 "&extrahosts=%7B%22database%22%3A+%22127.0.0.1%22%7D"
                 "&labels=%7B%22Unittest%22%3A+%22true%22%7D"
                 "&manifest=example%3Av1.2.3"
-                "&secrets=%5B%22id%3Dexample%2Csrc%3Dpodman-build-secret123%22%5D",
+                "&secrets=%5B%22id%3Dexample%2Csrc%3Dpodman-build-secret123%22%5D"
+                "&ssh=%5B%22default%22%5D",
                 text=buffer.getvalue(),
             )
             mock.get(
@@ -105,6 +107,7 @@ class TestBuildCase(unittest.TestCase):
                 labels={"Unittest": "true"},
                 manifest="example:v1.2.3",
                 secrets=["id=example,src=podman-build-secret123"],
+                ssh=["default"],
             )
             self.assertIsInstance(image, Image)
             self.assertEqual(image.id, good_image_id)


### PR DESCRIPTION
Allow passing SSH agent sockets or keys to the build API, similar to the existing secrets parameter support.
Fixes: https://github.com/containers/podman-py/issues/602

