### PR TITLE
Implement socket=True in Container.exec_run via connection hijacking

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -145,7 +145,7 @@ class Container(PodmanResource):
         user=None,
         detach: bool = False,
         stream: bool = False,
-        socket: bool = False,  # pylint: disable=unused-argument
+        socket: bool = False,
         environment: Union[Mapping[str, str], list[str]] = None,
         workdir: str = None,
         demux: bool = False,
@@ -182,9 +182,12 @@ class Container(PodmanResource):
                 If ``stream``, then a generator yielding response chunks.
                 If ``demux``, then a tuple of (``stdout``, ``stderr``).
                 Else the response content.
+                If ``socket``, then ``(None, socket)`` where ``socket`` is the
+                    raw bidirectional connection to the exec session
+                    (``stdin``/``stdout``/``stderr``). The caller is responsible
+                    for reading, writing and closing it.
 
         Raises:
-            NotImplementedError: method not implemented.
             APIError: when service reports error
         """
         # pylint: disable-msg=too-many-locals
@@ -210,6 +213,37 @@ class Container(PodmanResource):
         response = self.api.post(f"/containers/{self.name}/exec", data=json.dumps(data))
         response.raise_for_status()
         exec_id = response.json()['Id']
+        if socket:
+            # Hijack the connection: request a protocol upgrade on the exec
+            # start endpoint. After the "101 Switching Protocols" response the
+            # underlying UDS connection stops being HTTP and becomes a raw
+            # bidirectional byte channel attached to the exec session's
+            # stdin/stdout/stderr (raw stream with tty=True, multiplexed
+            # frames otherwise).
+            if self.client.base_url.scheme == "http+ssh":
+                raise NotImplementedError("exec_run(socket=True) is not supported over SSH")
+            start_resp = self.api.post(
+                f"/exec/{exec_id}/start",
+                data=json.dumps({"Detach": False, "Tty": tty}),
+                headers={"Connection": "Upgrade", "Upgrade": "tcp"},
+                stream=True,  # keep requests from consuming the stream body
+            )
+            start_resp.raise_for_status()
+            conn = start_resp.raw.connection
+            if conn is None or conn.sock is None:
+                raise APIError(
+                    f"/exec/{exec_id}/start",
+                    explanation="Unable to extract socket from hijacked connection",
+                    response=start_resp,
+                )
+            sock = conn.sock
+            # Anchor the response on the socket: if start_resp were released
+            # or garbage collected, urllib3 could return the hijacked
+            # connection to the pool and a later request would write HTTP
+            # into the exec session.
+            sock._hijacked_response = start_resp
+            return None, sock
+
         # start the exec instance, this will store command output
         start_resp = self.api.post(
             f"/exec/{exec_id}/start", data=json.dumps({"Detach": detach, "Tty": tty}), stream=stream

--- a/podman/tests/integration/test_container_exec.py
+++ b/podman/tests/integration/test_container_exec.py
@@ -120,3 +120,26 @@ class ContainersExecIntegrationTests(base.IntegrationTest):
             output,
             b'\n',
         )
+
+    def test_container_exec_run_socket(self):
+        """exec_run(socket=True) returns a live bidirectional socket."""
+        container = self.client.containers.create(self.alpine_image, command=["top"], detach=True)
+        self.containers.append(container)
+        container.start()
+
+        rc, sock = container.exec_run("/bin/sh", stdin=True, tty=True, socket=True)
+        self.assertIsNone(rc)
+
+        try:
+            sock.settimeout(5)
+            sock.sendall(b"echo $((100+11))\n")
+            data = b""
+            while b"111" not in data:
+                # the echo contains "100+11", never the literal "111":
+                # a computed marker distinguishes output from input echo
+                chunk = sock.recv(4096)
+                if not chunk:
+                    self.fail("socket closed before the marker was seen")
+                data += chunk
+        finally:
+            sock.close()

--- a/podman/tests/unit/test_container.py
+++ b/podman/tests/unit/test_container.py
@@ -2,6 +2,7 @@ import base64
 import io
 import json
 import unittest
+from unittest.mock import MagicMock
 
 try:
     # Python >= 3.10
@@ -16,6 +17,7 @@ from podman import PodmanClient, tests
 from podman.domain.containers import Container
 from podman.domain.containers_manager import ContainersManager
 from podman.errors import APIError, NotFound
+from unittest.mock import patch
 
 FIRST_CONTAINER = {
     "Id": "87e1325c82424e49a00abdd4de08009eb76c7de8d228426a9b8af9318ced5ecd",
@@ -472,6 +474,64 @@ class ContainersTestCase(unittest.TestCase):
             self.assertDictEqual(response, actual)
 
         self.assertTrue(adapter.called_once)
+
+    def test_exec_run_socket(self):
+        """exec_run(socket=True) sends the upgrade request and returns the hijacked socket."""
+        exec_resp = MagicMock()
+        exec_resp.raise_for_status.return_value = None
+        exec_resp.json.return_value = {"Id": "exec1"}
+
+        fake_sock = MagicMock()
+
+        start_resp = MagicMock()
+        start_resp.raise_for_status.return_value = None
+        start_resp.raw.connection.sock = fake_sock
+
+        container = Container(attrs=FIRST_CONTAINER, client=self.client.api)
+
+        with (
+            patch.object(container.api, "post") as post,
+            patch.object(container.api, "get") as get,
+        ):
+            post.side_effect = [exec_resp, start_resp]
+
+            rc, sock = container.exec_run(
+                "/bin/bash",
+                stdin=True,
+                tty=True,
+                socket=True,
+            )
+
+        # return contract: (None, socket), matching docker-py
+        self.assertIsNone(rc)
+        self.assertIs(sock, fake_sock)
+        # the response is anchored on the socket to keep the hijacked
+        # connection out of the urllib3 pool
+        self.assertIs(fake_sock._hijacked_response, start_resp)
+
+        # exactly two POSTs (exec create + exec start), nothing else:
+        # the socket branch must return immediately, without the
+        # blocking start/inspect path
+        self.assertEqual(post.call_count, 2)
+        get.assert_not_called()
+
+        # first call: exec create
+        self.assertEqual(
+            post.call_args_list[0].args[0],
+            f"/containers/{container.name}/exec",
+        )
+
+        # second call: start with connection upgrade, unconsumed body
+        self.assertEqual(post.call_args_list[1].args[0], "/exec/exec1/start")
+        self.assertEqual(
+            post.call_args_list[1].kwargs["headers"],
+            {"Connection": "Upgrade", "Upgrade": "tcp"},
+        )
+        self.assertTrue(post.call_args_list[1].kwargs["stream"])
+        self.assertEqual(
+            json.loads(post.call_args_list[1].kwargs["data"]),
+            {"Detach": False, "Tty": True},
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The libpod REST API supports upgrading the exec start request to a raw bidirectional stream (101 Switching Protocols). Send the Upgrade headers, keep the response unconsumed (stream=True) and hand the caller the underlying UDS socket, anchoring the response to keep the hijacked connection out of the urllib3 pool.

Fixes #421

Signed-off-by: Giovanni Oliverio oligiovi2@gmail.com

Fixes #421

## Problem

`Container.exec_run()` accepts a `socket` parameter (documented as "Return
the connection socket to allow custom read/write operations") but the
parameter is silently ignored: the call always blocks until the command
exits and returns the buffered output. This makes interactive exec
sessions (a shell with live stdin/stdout, terminal emulators, REPLs)
impossible with the native bindings, while the same use case works with
docker-py against Podman's compatibility socket.

The limitation is client-side only: the libpod REST API fully supports
hijacking the exec start request into a raw bidirectional stream.

## Solution

When `socket=True`, send the `POST /exec/{id}/start` request with
`Connection: Upgrade` / `Upgrade: tcp` headers and `stream=True` (so
`requests` does not consume the body). The server replies
`101 Switching Protocols` and the underlying connection stops being HTTP:
it becomes a raw bidirectional byte channel attached to the exec
session's stdin/stdout/stderr (raw stream with `tty=True`, multiplexed
frames otherwise). The socket is extracted from the response via
`response.raw._connection.sock` — `_connection` here is podman-py's own
`UDSConnection` (podman/api/uds.py), which keeps a reference to its
socket, so the only private attribute traversed is urllib3's
`HTTPResponse._connection`.

The response object is anchored on the returned socket
(`sock._hijacked_response`) so the hijacked connection cannot be released
back to the urllib3 pool while the caller is using it; a later request on
the same client would otherwise write HTTP into the exec session.

`Detach` is forced to `False` in this branch: a socket to a detached
session is meaningless (consistent with docker-py behaviour).

Return contract matches docker-py: `(None, socket)`; the caller is
responsible for reading, writing and closing the socket.

## Testing

- Unit test: verifies that `socket=True` issues the start request with
  the Upgrade headers, `stream=True` and `Detach: false`, and returns the
  extracted socket (extraction helper mocked, since the hijack cannot
  happen against requests_mock).
- Integration test: opens an interactive `/bin/sh` via
  `exec_run(socket=True)`, writes a command computing a marker and reads
  it back from the live socket.
- Manually validated against Podman 4.9.3 (rootless, crun, UDS) with
  podman-py 5.8.0: upgrade returns 101, the channel is bidirectional
  while the command is still running, terminal resize via
  `/exec/{id}/resize` is honoured, exit codes are reported by
  `/exec/{id}/json`, and concurrent requests on the same client open a
  separate pool connection without corrupting the hijacked stream.