### PR TITLE
Add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/actions/build-python-package/action.yml
+++ b/.github/actions/build-python-package/action.yml
@@ -27,19 +27,22 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       with:
         persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install build backend
       shell: bash
+      env:
+        BUILD_BACKEND: ${{ inputs.build-backend }}
       run: |
-        python3 -m pip install ${{ inputs.build-backend }} --user
+        # Intentionally unquoted so more than one backend can be passed.
+        python3 -m pip install $BUILD_BACKEND --user
 
     - name: Build distribution packages
       shell: bash
@@ -48,7 +51,7 @@ runs:
 
     - name: Upload distribution packages
       if: ${{ inputs.upload-artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.artifact-name }}
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,22 @@ name: Test Build Python distribution 📦
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
     name: Test Build Python distribution 📦
     runs-on: ubuntu-latest
     environment:
       name: build
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Build Python package
         uses: ./.github/actions/build-python-package

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -5,24 +5,28 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   create-release:
     # Only run if PR was merged and title starts with "Bump release to"
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Bump release to')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # to create tags and GitHub releases
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
+          persist-credentials: true # required to push the release tag
 
       - name: Extract version from PR title
         id: version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           # Extract version number from "Bump release to X.Y.Z"
           VERSION_NUMBER=$(echo "$PR_TITLE" | sed 's/Bump release to //')
           VERSION_TAG="v$VERSION_NUMBER"
@@ -37,8 +41,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create and push tag
+        env:
+          VERSION_TAG: ${{ steps.version.outputs.version_tag }}
         run: |
-          VERSION_TAG="${{ steps.version.outputs.version_tag }}"
           git tag "$VERSION_TAG"
           git push origin "$VERSION_TAG"
           echo "Created and pushed tag: $VERSION_TAG"
@@ -46,9 +51,8 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ steps.version.outputs.version_tag }}
         run: |
-          VERSION_TAG="${{ steps.version.outputs.version_tag }}"
-
           gh release create "$VERSION_TAG" \
             --title "$VERSION_TAG" \
             --generate-notes \

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -8,18 +8,21 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # to push the release branch
+      pull-requests: write # to open the release PR
 
     steps:
       - name: Validate and extract version
         id: version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
           if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+){2,}$ ]]; then
             echo "Error: Version must start with 'v' followed by numbers and dots (e.g., v5.8.0)"
             echo "Provided version: $VERSION"
@@ -32,15 +35,19 @@ jobs:
           echo "version_tag=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Update version files
+        env:
+          VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
         run: |
           chmod +x .github/scripts/update-version.sh
-          ./.github/scripts/update-version.sh "${{ steps.version.outputs.version_number }}"
+          ./.github/scripts/update-version.sh "$VERSION_NUMBER"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: release/${{ steps.version.outputs.version_tag }}
           delete-branch: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,20 +2,25 @@ name: validate
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   commit:
     runs-on: ubuntu-24.04
     # Only check commits on pull requests.
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read # to list commits on the pull request
     steps:
       - name: get pr commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.1
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check subject line length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.2
+        uses: tim-actions/commit-message-checker-with-regex@094fc16ff83d04e2ec73edb5eaf6aa267db33791 # v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,72}(\n.*)*$'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,16 +3,23 @@ on:
   pull_request:
   push:
     branches: [main]
+
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SKIP: no-commit-to-branch
     steps:
-    - uses: actions/checkout@v5
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: |
           3.9
           3.x
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,13 +5,19 @@ on:
     tags:
       - 'v[0-9]+\.[0-9]+\.[0-9]+\.?[0-9]?'
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Build Python package
         uses: ./.github/actions/build-python-package
@@ -33,9 +39,11 @@ jobs:
 
     steps:
       - name: Download artifacts from build job
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: python-package-distributions-pypi
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # PyPA recommends the floating release/v1 tag so that fixes to the
+        # trusted publishing flow are picked up automatically.
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,13 +5,19 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Build Python package
         uses: ./.github/actions/build-python-package
@@ -34,12 +40,14 @@ jobs:
 
     steps:
       - name: Download artifacts from build job
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: python-package-distributions-testpypi
           path: dist/
       - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # PyPA recommends the floating release/v1 tag so that fixes to the
+        # trusted publishing flow are picked up automatically.
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: 'zizmor: GitHub Actions Security Analysis'
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # to create vulnerability alerts
+      contents: read # to read repo contents
+      actions: read # to read GitHub actions info
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Adds the [zizmor](https://docs.zizmor.sh/) static analysis workflow for GitHub
Actions

local run:
``` WARN audit: zizmor: zizmor is running in offline mode by default; some audits and auto-fixes will not be available. see https://docs.zizmor.sh/usage/#operating-modes for details
 INFO audit: zizmor: 🌈 completed ./.github/workflows/build.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/create-github-release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/create-release-pr.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/pr.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/pre-commit.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish-to-pypi.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish-to-test-pypi.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/zizmor.yml
No findings to report. Good job! (2 ignored, 13 suppressed)```